### PR TITLE
Do not specify relative path for bower command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "migrate": "node_modules/.bin/migrate",
     "start": "node web/index.js",
-    "postinstall": "cd web && ../node_modules/.bin/bower install",
+    "postinstall": "cd web && bower install",
     "test": "grunt test"
   },
   "repository": {


### PR DESCRIPTION
node_modules/.bin will already be in the path when the postinstall script runs.

@dberesford @iantocristian please review
