### PR TITLE
Fix bullet point text in charter

### DIFF
--- a/web/locale/en_US/messages.po
+++ b/web/locale/en_US/messages.po
@@ -269,7 +269,7 @@ msgstr "HWF commits to act in the interest of the global CoderDojo community"
 msgid "charter.li12"
 msgstr "HWF commits to facilitating the community to share its knowledge"
 
-msgid "charter.li3"
+msgid "charter.li13"
 msgstr "HWF commits to sharing our resources for free"
 
 msgid "charter.li14"


### PR DESCRIPTION
Typo meant bullet point was showing up as "charter.li3" on Charter page
