### PR TITLE
Small issues

### DIFF
--- a/lib/events/cd-events.js
+++ b/lib/events/cd-events.js
@@ -42,7 +42,7 @@ module.exports = function(options) {
 
     if(!attendance) return done(new Error('Attendance Record must exist'));
 
-    var eventId = attendance.eventId || attendance.event_id;
+    var eventId = attendance.eventId;
     getEventById(eventId, function(err, event){
       if (err) return done(err);
       var dojoId = event.dojoId;
@@ -53,7 +53,7 @@ module.exports = function(options) {
   function eventValidationProxy(args, done) {
     var user = args.req$.seneca.user;
     var eventInfo = args.eventInfo;
-    var eventId = args.eventId || args.event_id;
+    var eventId = args.eventId;
 
     if(!user) {
       return done(new Error('User must exist'));
@@ -87,7 +87,7 @@ module.exports = function(options) {
 
     if(!application) return done(new Error('Application must exist'));
 
-    var eventId = application.eventId || application.event_id;
+    var eventId = application.eventId;
     getEventById(eventId, function(err, event){
       if (err) return done(err);
       var dojoId = event.dojoId;
@@ -100,7 +100,7 @@ module.exports = function(options) {
     var applications = args.applications;
 
     if(applications.length === 0) return done(new Error('Applications must exist'));
-    var eventId = applications[0].eventId || applications[0].event_id;
+    var eventId = applications[0].eventId;
     getEventById(eventId, function(err, event){
       if (err) return done(err);
       var dojoId = event.dojoId;

--- a/web/public/js/controllers/dojo-events-list-controller.js
+++ b/web/public/js/controllers/dojo-events-list-controller.js
@@ -2,7 +2,7 @@
 
 function cdDojoEventsListCtrl($scope, $state, $location, $translate, $q, cdEventsService, cdUsersService, cdDojoService, tableUtils, alertService, auth) {
   var dojoId = $scope.dojoId;
-  $scope.filter = {dojo_id:dojoId};
+  $scope.filter = {dojoId:dojoId};
   $scope.itemsPerPage = 10;
   $scope.applyData = {};
 
@@ -56,7 +56,7 @@ function cdDojoEventsListCtrl($scope, $state, $location, $translate, $q, cdEvent
       query: {
         bool: {
           must:[
-            { match: { dojo_id: dojoId }},
+            { match: { dojoId: dojoId }},
             { match: { status: 'published' }},
             { match: { public: true}},
             { 
@@ -80,7 +80,7 @@ function cdDojoEventsListCtrl($scope, $state, $location, $translate, $q, cdEvent
     $scope.sort = $scope.sort ? $scope.sort :[{ dates: {order:'asc', ignore_unmapped:true}}];
 
     var query = _.omit({
-      dojo_id: filter.dojo_id,
+      dojoId: filter.dojoId,
     }, function (value) { return value === '' || _.isNull(value) || _.isUndefined(value) });
 
     var loadPageData = tableUtils.loadPage(resetFlag, $scope.itemsPerPage, $scope.pageNo, query);

--- a/web/public/js/controllers/manage-dojo-controller.js
+++ b/web/public/js/controllers/manage-dojo-controller.js
@@ -351,7 +351,7 @@ function manageDojosCtrl($scope, alertService, auth, tableUtils, cdDojoService, 
     }
 
     var query = {limit$: 'NULL'};
-    query.user_id = item.id;
+    query.userId = item.id;
 
     cdDojoService.getUsersDojos(query, function(usersDojos){
       var dojoIds = _.pluck(usersDojos, 'dojoId');

--- a/web/public/js/controllers/manage-dojo-events-controller.js
+++ b/web/public/js/controllers/manage-dojo-events-controller.js
@@ -3,7 +3,7 @@
 
   function manageDojoEventsCtrl($scope, $stateParams, $state, $location, cdDojoService, cdEventsService, tableUtils, $translate, auth) {
     $scope.dojoId = $stateParams.dojoId;
-    $scope.filter = {dojo_id: $scope.dojoId};
+    $scope.filter = {dojoId: $scope.dojoId};
     $scope.itemsPerPage = 10;
     $scope.pagination = {};
     $scope.manageDojoEventsPageTitle = $translate.instant('Manage Dojo Events'); //breadcrumb page title
@@ -43,8 +43,8 @@
       var dojoQuery = { query: {
                           bool: {
                             must:[
-                              { match: { dojo_id: $scope.dojoId }}
-                            ]   
+                              { match: { dojoId: $scope.dojoId }}
+                            ]
                           }
                         }
                       };
@@ -52,7 +52,7 @@
       $scope.sort = $scope.sort ? $scope.sort :[{ dates: {order: 'asc', ignore_unmapped: true }}];
 
       var query = _.omit({
-        dojo_id: filter.dojo_id,
+        dojoId: filter.dojoId,
       }, function (value) { return value === '' || _.isNull(value) || _.isUndefined(value) });
 
       var loadPageData = tableUtils.loadPage(resetFlag, $scope.itemsPerPage, $scope.pagination.pageNo, query);
@@ -83,7 +83,7 @@
           }
           
           //Retrieve number of applicants & attendees
-          var cdApplicationsQuery = {query:{match:{event_id:event.id}}};
+          var cdApplicationsQuery = {query:{match:{eventId:event.id}}};
           cdEventsService.searchApplications(cdApplicationsQuery, function (result) {
             var numOfApplicants = result.total;
             var numAttending = 0;

--- a/web/public/js/controllers/manage-event-applications-controller.js
+++ b/web/public/js/controllers/manage-event-applications-controller.js
@@ -3,7 +3,7 @@
 function manageEventApplicationsControllerCtrl($scope, $stateParams, $translate, alertService, cdEventsService, tableUtils, cdDojoService, cdUsersService, AlertBanner) {
   var eventId = $stateParams.eventId;
   var dojoId = $stateParams.dojoId;
-  $scope.filter = {event_id: eventId};
+  $scope.filter = {eventId: eventId};
   $scope.sort = undefined;
   $scope.itemsPerPage = 10;
   $scope.pagination = {};
@@ -24,9 +24,9 @@ function manageEventApplicationsControllerCtrl($scope, $stateParams, $translate,
       var newApplicant = {
         name: dojoMember.name,
         dateOfBirth: userProfile.dob,
-        event_id: eventId,
+        eventId: eventId,
         status: 'pending',
-        user_id: dojoMember.id
+        userId: dojoMember.id
       };
 
       cdEventsService.saveApplication(newApplicant, function (response) {
@@ -60,11 +60,11 @@ function manageEventApplicationsControllerCtrl($scope, $stateParams, $translate,
     $scope.attending = 0;
     $scope.waitlist = 0;
 
-    var eventApplicationsQuery = {query: {match: {event_id: eventId}}};
+    var eventApplicationsQuery = {query: {match: {eventId: eventId}}};
     $scope.sort = $scope.sort ? $scope.sort : [{name: {order: 'asc', ignore_unmapped: true}}];
 
     var query = _.omit({
-      event_id: filter.event_id,
+      eventId: filter.eventId,
     }, function (value) {
       return value === '' || _.isNull(value) || _.isUndefined(value)
     });

--- a/web/public/js/controllers/manage-event-attendance-controller.js
+++ b/web/public/js/controllers/manage-event-attendance-controller.js
@@ -61,8 +61,8 @@
             query: {
               bool: {
                 must: [
-                  { match: { event_id: eventId }},
-                  { match: { event_date: $scope.attendance.eventDate.date }}
+                  { match: { eventId: eventId }},
+                  { match: { eventDate: $scope.attendance.eventDate.date }}
                 ]
               }
             }
@@ -72,7 +72,7 @@
 
       var meta = {
         sort: {
-          event_date: {
+          eventDate: {
             order: sortDirection,
             ignore_unmapped: true
           }

--- a/web/public/js/controllers/start-dojo-wizard-controller.js
+++ b/web/public/js/controllers/start-dojo-wizard-controller.js
@@ -505,7 +505,7 @@ function startDojoWizardCtrl($scope, $http, $window, $state, $stateParams, $loca
             cdDojoService.save(dojo, function (response) {
 
               //update intercom champion dojos
-              intercomService.updateIntercom(response.dojo_id);
+              intercomService.updateIntercom(response.dojoId);
 
               $state.go('dojo-list', {
                 bannerType:'success',


### PR DESCRIPTION
@dberesford this is big. I don't know how I or anybody haven't noticed this before or haven't reported it. Because Elasticsearch attrs were indexed as snake case for events and users services there was big inconsistency between data returned from services(directly from postgres) which was camelCase and data returned from ES which was snake_case for this two services. 

There were lots of fixes like var eventId = attendance.eventId || attendance.event_id. 
This might crash the ES indexes for events since ES was removed from users.

Other similar PR's to come in dojos and events services
