### PR TITLE
patched mydojos controller so it now works with migrated data

### DIFF
--- a/web/public/js/controllers/my-dojos-controller.js
+++ b/web/public/js/controllers/my-dojos-controller.js
@@ -127,7 +127,7 @@ function cdMyDojosCtrl($q, $rootScope, $localStorage, $scope, $state, $statePara
             dojo.isChampion = isChampion;
             dojo.isTicketingAdmin = isTicketingAdmin;
             dojo.isDojoAdmin = isDojoAdmin;
-            dojo.country = dojo.country.alpha2.toLowerCase();
+            dojo.country = dojo.alpha2.toLowerCase();
             var path = dojo.urlSlug.split('/');
             path.splice(0, 1);
             path = path.join('/');


### PR DESCRIPTION
The dojo.country.alpha2 is undefined on migrated data, but the dojo.alpha2 is defined, because all dojos have this set from the long/lat data... It seems this is an adequate fix to a nuisance issue. afaik, the `dojo.country` variable which is being set in the controller is never used on the template anyway, so it can probably be removed fully. 
