### PR TITLE
Add message to top of past event to explain it is not editable

### DIFF
--- a/web/public/templates/dojos/events/dojo-event-form.dust
+++ b/web/public/templates/dojos/events/dojo-event-form.dust
@@ -1,4 +1,5 @@
 <div class="cd-dashboard cd-color-3-underline event-form">
+  <div ng-if="pastEvent" class="alert alert-info">You are viewing a past event which is not possible to edit.</div>
   <form name="eventForm" novalidate angular-validator angular-validator-submit="submit(eventInfo)">
     <legend ng-if="!isEditMode">{@i18n key="Create Event"/}</legend>
     <legend ng-if="isEditMode">{@i18n key="Edit Event"/}</legend>


### PR DESCRIPTION
Show a message at the top of the edit event page for past events