### PR TITLE
Scroll to validation error on all forms

### DIFF
--- a/web/public/js/controllers/dojo-event-form-controller.js
+++ b/web/public/js/controllers/dojo-event-form-controller.js
@@ -351,7 +351,16 @@
 
 
     };
-
+    
+    $scope.scrollToInvalid = function (form) {
+        if (form.$invalid) {
+            angular.element('form[name=' + form.$name + '] .ng-invalid')[0].scrollIntoView();
+        } else {
+            eventInfo.publish=true;
+        }
+    };
+    
+    
     $scope.submit = function(eventInfo) {
       usSpinnerService.spin('create-event-spinner');
 

--- a/web/public/js/controllers/start-dojo-wizard-controller.js
+++ b/web/public/js/controllers/start-dojo-wizard-controller.js
@@ -493,6 +493,7 @@ function startDojoWizardCtrl($scope, $window, $state, $location, auth, alertServ
         $scope.steps.map(function(step){
           step.open = true;
         });
+        angular.element('form[name=' + context.setupYourDojoForm.$name + '] .ng-invalid')[0].scrollIntoView();
       }
     };
 

--- a/web/public/js/controllers/user-profile-controller.js
+++ b/web/public/js/controllers/user-profile-controller.js
@@ -531,6 +531,12 @@ function cdUserProfileCtrl($scope, $rootScope, $state, auth, cdUsersService, cdD
     $scope.inviteNinjaPopover.show = !$scope.inviteNinjaPopover.show;
   }
 
+  $scope.scrollToInvalid = function (form) {
+      if (form.$invalid) {
+          angular.element('form[name=' + form.$name + '] .ng-invalid')[0].scrollIntoView();
+      }
+  };
+
 }
 
 angular.module('cpZenPlatform')

--- a/web/public/templates/dojos/events/dojo-event-form.dust
+++ b/web/public/templates/dojos/events/dojo-event-form.dust
@@ -262,7 +262,7 @@
     <div class="btn-toolbar">
       <button type="button" class="btn btn-default" ng-click="cancel($event)">{@i18n key="Cancel"/}</button>
       <button ng-if="!pastEvent" type="submit" class="btn btn-primary" >{@i18n key="Save Draft"/}</button>
-      <button ng-if="!pastEvent" type="submit" class="btn btn-success" ng-click="eventInfo.publish=true">{@i18n key="Publish"/}</button>
+      <button ng-if="!pastEvent" type="submit" class="btn btn-success" ng-click="scrollToInvalid(eventForm)">{@i18n key="Publish"/}</button>
     </div>
   </form>
 

--- a/web/public/templates/profiles/general-info.dust
+++ b/web/public/templates/profiles/general-info.dust
@@ -177,7 +177,7 @@
           </div>
         </div>
         <br>
-        <button type="submit" class="btn btn-primary pull-right">{@i18n key="Save"/}</button>
+        <button type="submit" class="btn btn-primary pull-right" ng-click="scrollToInvalid(generalInfoForm)">{@i18n key="Save"/}</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
This is related to [CoderDojo/community-platform/issues/605](https://github.com/CoderDojo/community-platform/issues/605)

I added the scrolling feature to the hinted form "add event"
I also went on to find which other forms were long enough for this to make sense.
 - "Edit Profile" page now has the scrolling (remove the name and try to save)
 - "Setup Dojo" accordion menu will open all sections like it used to, once that's done it'll scroll to the first validation error.