### PR TITLE
swagger validation enhancements

### DIFF
--- a/lib/dojos.js
+++ b/lib/dojos.js
@@ -56,9 +56,9 @@ var joiValidator = {
       phone: joiValidator.phone(),
       country: joiValidator.country(),
       placeName: Joi.string(),
-      county: Joi.object(),
-      state: Joi.object(),
-      city: Joi.object(),
+      county: Joi.object().allow(null),
+      state: Joi.object().allow(null),
+      city: Joi.object().allow(null),
       place: joiValidator.place(),
       countryName: Joi.string().required(),
       countryNumber: Joi.number().integer().required(),
@@ -116,7 +116,7 @@ var joiValidator = {
   },
   user: function() {
     return Joi.object().keys({
-      id: Joi.string().guid().required(),
+      id: joiValidator.guid().required(),
       nick: Joi.string(),
       email: joiValidator.mail().required(),
       name: Joi.string().required(),
@@ -144,6 +144,9 @@ var joiValidator = {
       joinRequests: Joi.any(),
       lastLogin: Joi.date()
     });
+  },
+  guid: function() {
+    return Joi.alternatives().try(Joi.string().guid(), Joi.string());
   }
 }
 
@@ -210,7 +213,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         payload: Joi.object({ query: {
-          dojoLeadId: Joi.string().guid(),
+          dojoLeadId: joiValidator.guid(),
           urlSlug: Joi.string()
         }})
       }
@@ -271,9 +274,9 @@ exports.register = function (server, options, next) {
             time: Joi.string(),
             country: joiValidator.country(),
             placeName: Joi.string().required(),
-            county: Joi.object(),
-            state: Joi.object(),
-            city: Joi.object(),
+            county: Joi.object().allow(null),
+            state: Joi.object().allow(null),
+            city: Joi.object().allow(null),
             place: joiValidator.place(),
             countryName: Joi.string().required(),
             countryNumber: Joi.number().integer(),
@@ -289,7 +292,7 @@ exports.register = function (server, options, next) {
             twitter: joiValidator.twitter(),
             supporterImage: joiValidator.uri(),
             mailingList: Joi.number().integer(),
-            dojoLeadId: Joi.string().guid().required(),
+            dojoLeadId: joiValidator.guid().required(),
             emailSubject: Joi.string().required()
           }})
         }
@@ -316,23 +319,23 @@ exports.register = function (server, options, next) {
         },
         payload: Joi.object({ dojo: {
           entity$: Joi.string(),
-          id: Joi.string().guid(),
+          id: joiValidator.guid(),
           mysqlDojoId: Joi.any(),
-          dojoLeadId: Joi.string().guid(),
+          dojoLeadId: joiValidator.guid(),
           name: Joi.string(),
-          creator: Joi.string().guid(),
+          creator: joiValidator.guid(),
           created: Joi.date(),
           verifiedAt: Joi.alternatives().try(Joi.date(), Joi.string().valid(null)),
-          verifiedBy: Joi.alternatives().try(Joi.string().guid(), Joi.string().valid(null)),
+          verifiedBy: Joi.alternatives().try(joiValidator.guid(), Joi.string().valid(null)),
           verified: Joi.number().valid(0).valid(1),
           needMentors: Joi.number().valid(0).valid(1),
           stage: Joi.number().integer(),
           mailingList: Joi.number().integer(),
           time: Joi.alternatives().try(Joi.string(), Joi.string().valid(null)),
           country: joiValidator.country(),
-          county: Joi.object(),
-          state: Joi.object(),
-          city: Joi.object(),
+          county: Joi.object().allow(null),
+          state: Joi.object().allow(null),
+          city: Joi.object().allow(null),
           place: joiValidator.place(),
           coordinates: Joi.string(),
           geoPoint: Joi.object().keys({
@@ -560,9 +563,9 @@ exports.register = function (server, options, next) {
       validate: {
         payload: Joi.object({ dojos:
           Joi.array().items(Joi.object().keys({
-            id: Joi.string().guid(),
+            id: joiValidator.guid(),
             verified: Joi.number().valid(0).valid(1),
-            dojoLeadId: Joi.string().guid()
+            dojoLeadId: joiValidator.guid()
           }))
         })
       }
@@ -586,9 +589,9 @@ exports.register = function (server, options, next) {
       validate: {
         payload: Joi.object({ dojos:
           Joi.array().items(Joi.object().keys({
-            id: Joi.string().guid(),
-            creator: Joi.string().guid(),
-            dojoLeadId: Joi.string().guid()
+            id: joiValidator.guid(),
+            creator: joiValidator.guid(),
+            dojoLeadId: joiValidator.guid()
           }))
         })
       }
@@ -628,7 +631,7 @@ exports.register = function (server, options, next) {
       validate: {
         payload: Joi.object({ dojoLead: {
           application: joiValidator.application(),
-          userId: Joi.string().guid().required(),
+          userId: joiValidator.guid().required(),
           email: joiValidator.mail().required(),
           currentStep: Joi.number().integer().required(),
           migration: Joi.any(),
@@ -657,11 +660,11 @@ exports.register = function (server, options, next) {
         },
         payload: Joi.object({ dojoLead: {
           entity$: Joi.string(),
-          userId: Joi.string().guid().required(),
+          userId: joiValidator.guid().required(),
           email: joiValidator.mail().required(),
           application: joiValidator.application(),
           currentStep: Joi.number().integer().required(),
-          id: Joi.string().guid().required(),
+          id: joiValidator.guid().required(),
           completed: Joi.boolean(),
           deleted: Joi.number().valid(0).valid(1),
           deletedBy: Joi.any(),
@@ -747,8 +750,8 @@ exports.register = function (server, options, next) {
       },
       validate: {
         payload: Joi.object({ query: {
-          dojoId: Joi.alternatives().try(Joi.string().guid(), Joi.string().valid("")),
-          userId: Joi.string().guid(),
+          dojoId: Joi.alternatives().try(joiValidator.guid(), Joi.string().valid("")),
+          userId: joiValidator.guid(),
           deleted: Joi.number().valid(0).valid(1),
           owner: Joi.number().valid(1).valid(0),
           limit$: Joi.number().integer().min(0).optional(),
@@ -774,7 +777,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         payload: Joi.object({ query: {
-          userId: Joi.string().guid()
+          userId: joiValidator.guid()
         }})
       }
     }
@@ -812,7 +815,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         payload: Joi.object({ query: {
-          dojoId: Joi.string().guid(),
+          dojoId: joiValidator.guid(),
           deleted: Joi.number().valid(0).valid(1),
           limit$: Joi.alternatives().try(Joi.number().integer().min(0), Joi.string()),
           skip$: Joi.number().integer().min(0).optional(),
@@ -842,7 +845,7 @@ exports.register = function (server, options, next) {
           email: joiValidator.mail().required(),
           emailSubject: Joi.string().required(),
           userType: Joi.string().required(),
-          dojoId: Joi.string().guid().required()
+          dojoId: joiValidator.guid().required()
         })
       }
     }
@@ -873,7 +876,7 @@ exports.register = function (server, options, next) {
       validate: {
         payload: Joi.object({ data: {
           user: joiValidator.user().required(),
-          dojoId: Joi.string().guid().required(),
+          dojoId: joiValidator.guid().required(),
           userType: Joi.string().required(),
           emailSubject: Joi.string()
         }})
@@ -927,12 +930,12 @@ exports.register = function (server, options, next) {
       validate: {
         payload: Joi.object({ userDojo: {
           entity$: Joi.string(),
-          id: Joi.string().guid(),
+          id: joiValidator.guid(),
           mysqlUserId: Joi.any(),
           mysqlDojoId: Joi.any(),
           owner: Joi.number().valid(1).valid(0),
-          userId: Joi.string().guid(),
-          dojoId: Joi.string().guid(),
+          userId: joiValidator.guid(),
+          dojoId: joiValidator.guid(),
           userTypes: Joi.array(),
           userPermissions: Joi.alternatives().try(Joi.array(), Joi.string().valid(null)),
           backgroundChecked: Joi.boolean(),
@@ -960,8 +963,8 @@ exports.register = function (server, options, next) {
       },
       validate: {
         params: {
-          userId: Joi.string().guid().required(),
-          dojoId: Joi.string().guid().required()
+          userId: joiValidator.guid().required(),
+          dojoId: joiValidator.guid().required()
         }
       }
     }


### PR DESCRIPTION
Added `joiValidator.guid()` that allows both `guid()` and `string()`
Allow `object` or `null` for `country, state, city`