### PR TITLE
fix #547 from the community-platform repo

### DIFF
--- a/web/public/css/dashboard.less
+++ b/web/public/css/dashboard.less
@@ -416,6 +416,9 @@ label {
       color:@cd-body-color-3;
       font-weight:bold;
     }
+    img {
+      max-width:100%;
+    }
   }
   .events-sessions {
     padding-top:10px;

--- a/web/public/js/controllers/dojo-event-form-controller.js
+++ b/web/public/js/controllers/dojo-event-form-controller.js
@@ -128,6 +128,13 @@
     $scope.datepicker = {};
     $scope.datepicker.minDate = now;
 
+    //description editor
+    $scope.editorOptions = {
+      language: 'en',
+      uiColor: '#000000',
+      height: '200px'
+    };
+
     $scope.$watch('eventInfo.date', function (date) {
       $scope.eventInfo.fixedStartDateTime = fixEventDates(date, $scope.eventInfo.fixedStartDateTime);
       $scope.eventInfo.startTime = $scope.eventInfo.fixedStartDateTime;

--- a/web/public/templates/dojos/events/apply.dust
+++ b/web/public/templates/dojos/events/apply.dust
@@ -18,7 +18,7 @@
       <p>{{ event.city.nameWithHierarchy }}</p>
     </div>
     <div class="col-md-6">
-      <p>{{ event.description }}</p>
+      <p><div ng-bind-html="event.description"></div></p>
     </div>
   </div>
 

--- a/web/public/templates/dojos/events/dojo-event-form.dust
+++ b/web/public/templates/dojos/events/dojo-event-form.dust
@@ -18,10 +18,10 @@
       </div>
       <span tooltip="{@i18n key="Public events are viewable by anyone visiting your Dojo listing. Private events can only be seen by members of your Dojo."/}" tooltip-placement="right" class="info-button fa fa-info-circle event-tooltip"></span>
     </div>
+
     <div class="form-group">
       <label for="description">{@i18n key="Description"/}*:</label>
-      <textarea name="description" required required-message="'{@i18n key="Description is empty"/}'" id="description" class="form-control" rows="3" ng-model="eventInfo.description" placeholder="{@i18n key="Add a description"/}" ng-change="updateLocalStorage('description',eventInfo.description)">
-      </textarea>
+        <textarea name="description" required required-message="'{@i18n key="Description is empty"/}'" ng-if="editorOptions" ckeditor="editorOptions" id="description" class="form-control" rows="3" ng-model="eventInfo.description" placeholder="{@i18n key="Add a description"/}" ng-change="updateLocalStorage('description',eventInfo.description)"></textarea>
     </div>
 
     <div class="form-group form-inline">


### PR DESCRIPTION
changed the event description input field to a html input box like the one used in the dojo form.
changed the event template to display the description as html