### PR TITLE
Add banner to top of profile

### DIFF
--- a/web/locale/en_US/messages.po
+++ b/web/locale/en_US/messages.po
@@ -2660,3 +2660,6 @@ msgstr "If you need to book in to a Dojo event, you need to fill out your parent
 
 msgid "Not all information entered on your profile is viewable. You can choose to hide certain information by ticking the hide buttons at the bottom of the page."
 msgstr "Not all information entered on your profile is viewable. You can choose to hide certain information by ticking the hide buttons at the bottom of the page."
+
+msgid "Only your username and profile picture are publicly viewable. Other fields are for administration purposes only."
+msgstr "Only your username and profile picture are publicly viewable. Other fields are for administration purposes only."

--- a/web/locale/en_US/messages.po
+++ b/web/locale/en_US/messages.po
@@ -2651,3 +2651,12 @@ msgstr "Error loading parents"
 
 msgid "You are viewing a past event which is not possible to edit."
 msgstr "You are viewing a past event which is not possible to edit."
+
+msgid "Registering for an event?"
+msgstr "Registering for an event?"
+
+msgid "If you need to book in to a Dojo event, you need to fill out your profile first. Then you will need to <a href=\"#ninjas\">add ninjas</a> to your profile. Following this you may <a href=\"/\">find your local Dojo</a> and book an event via the Dojo listing"
+msgstr "If you need to book in to a Dojo event, you need to fill out your parent profile first. Then you will need to <a href=\"#ninjas\">add ninjas</a> to your profile. Following this you may <a href=\"/\">find your local Dojo</a> and book an event on the Dojo listing page."
+
+msgid "Not all information entered on your profile is viewable. You can choose to hide certain information by ticking the hide buttons at the bottom of the page."
+msgstr "Not all information entered on your profile is viewable. You can choose to hide certain information by ticking the hide buttons at the bottom of the page."

--- a/web/public/templates/profiles/children-list.dust
+++ b/web/public/templates/profiles/children-list.dust
@@ -1,4 +1,5 @@
 <div id="ninjaProfileBlock" class="profile-section">
+  <a name="ninjas"></a>
   <legend class="legend-color-3-border">{@i18n key="Ninjas"/}</legend>
   <div class="col-xs-12">
     <button ng-click="toggleInviteNinjaPopover()" ng-if="editMode && (loggedInUser.id === profile.userId)" popover-toggle="inviteNinjaPopover.show" popover-template="'{{ inviteNinjaPopover.templateUrl }}'" popover-placement="{{ inviteNinjaPopover.placement }}" popover-title="{{ inviteNinjaPopover.title }}" class="btn btn-sm btn-primary panel-heading-button pull-right">{@i18n key="Invite Ninja over 13"/}</button>

--- a/web/public/templates/profiles/general-info.dust
+++ b/web/public/templates/profiles/general-info.dust
@@ -1,4 +1,11 @@
 <div ng-if="editMode">
+  <div class="alert alert-info">
+    {@i18n key="Registering for an event?"/}<br />
+    {@i18n key="If you need to book in to a Dojo event, you need to fill out your profile first. Then you will need to <a href=\"#ninjas\">add ninjas</a> to your profile. Following this you may <a href=\"/\">find your local Dojo</a> and book an event on the Dojo listing page."/}
+  </div>
+  <div class="alert alert-info">
+    {@i18n key="Not all information entered on your profile is viewable. You can choose to hide certain information by ticking the hide buttons at the bottom of the page."/}
+  </div>
   <legend class="legend-color-1-border">{@i18n key="General Info"/}</legend>
   <div class="panel-body">
     <div>

--- a/web/public/templates/profiles/general-info.dust
+++ b/web/public/templates/profiles/general-info.dust
@@ -1,9 +1,12 @@
 <div ng-if="editMode">
   <div class="alert alert-info">
-    {@i18n key="Registering for an event?"/}<br />
+    <strong>{@i18n key="Registering for an event?"/}</strong><br />
     {@i18n key="If you need to book in to a Dojo event, you need to fill out your profile first. Then you will need to <a href=\"#ninjas\">add ninjas</a> to your profile. Following this you may <a href=\"/\">find your local Dojo</a> and book an event on the Dojo listing page."/}
   </div>
-  <div class="alert alert-info">
+  <div class="alert alert-info" ng-if="parentProfile">
+    {@i18n key="Only your username and profile picture are publicly viewable. Other fields are for administration purposes only."/}
+  </div>
+  <div class="alert alert-info" ng-if="!parentProfile">
     {@i18n key="Not all information entered on your profile is viewable. You can choose to hide certain information by ticking the hide buttons at the bottom of the page."/}
   </div>
   <legend class="legend-color-1-border">{@i18n key="General Info"/}</legend>


### PR DESCRIPTION
Two banners - one to explain that you are not booked in to an event once you fill out your profile.

The other to explain that not all fields on your profile are public.

It seems like users think that once they have signed up to the system they are booked into an event which is not so.

Also add a link in the events explanation to the ninjas section of the profile