### PR TITLE
Updates to registration page

### DIFF
--- a/web/locale/en_US/messages.po
+++ b/web/locale/en_US/messages.po
@@ -36,6 +36,9 @@ msgstr "Forgot password?"
 msgid "Register"
 msgstr "Register"
 
+msgid "Register an account"
+msgstr "Register an account"
+
 msgid "Email"
 msgstr "Email"
 
@@ -2663,3 +2666,6 @@ msgstr "Not all information entered on your profile is viewable. You can choose 
 
 msgid "Only your username and profile picture are publicly viewable. Other fields are for administration purposes only."
 msgstr "Only your username and profile picture are publicly viewable. Other fields are for administration purposes only."
+
+msgid "Registering an account does not guarantee you entry to a Dojo event. To gain entry to an event you must fill out your profile and book via the Dojo listing page. You will need your email confirmation to attend or direct permission from the Dojo administrators."
+msgstr "Registering an account does not guarantee you entry to a Dojo event. To gain entry to an event you must fill out your profile and book via the Dojo listing page. You will need your email confirmation to attend or direct permission from the Dojo administrators."

--- a/web/public/templates/dojos/start-dojo-wizard/step-one-register.dust
+++ b/web/public/templates/dojos/start-dojo-wizard/step-one-register.dust
@@ -1,6 +1,10 @@
 <div id="main" class="user-registration cd-color-4-underline">
   <form id="user-registration-form" name="registerForm" novalidate angular-validator angular-validator-submit="doRegister(registerUser)" role="form" class="form-horizonal">
-    <legend>{@i18n key="Register"/}</legend>
+    <div class="alert alert-info">
+      <strong>{@i18n key="Registering for an event?"/}</strong><br />
+      {@i18n key="Registering an account does not guarantee you entry to a Dojo event. To gain entry to an event you must fill out your profile and book via the Dojo listing page. You will need your email confirmation to attend or direct permission from the Dojo administrators."/}
+    </div>
+    <legend>{@i18n key="Register an account"/}</legend>
     <div class="row"></div>
     <div class="row cd-input-row" ng-enter="noop()">
       <div class="form-group">


### PR DESCRIPTION
- Add message to registration page to explain that the user is registering an account rather than registering for an event
- Change "register" to "register an account" to make it explicit what the registration page does

Ref https://github.com/CoderDojo/community-platform/issues/816