### PR TITLE
Fix for sorting crashes when managing dojos. #848

### DIFF
--- a/lib/dojos.js
+++ b/lib/dojos.js
@@ -279,7 +279,11 @@ exports.register = function (server, options, next) {
           limit$: Joi.number().integer().min(0).optional(),
           skip$: Joi.number().integer().min(0).optional(),
           sort$: Joi.object().keys({
-            created: Joi.number().valid(-1).valid(1).optional()
+            created: Joi.number().valid(-1).valid(1).optional(),
+            name: Joi.number().valid(-1).valid(1).optional(),
+            stage: Joi.number().valid(-1).valid(1).optional(),
+            alpha2: Joi.number().valid(-1).valid(1).optional(),
+            email: Joi.number().valid(-1).valid(1).optional()
           })
         }})
       }


### PR DESCRIPTION
As per title. It was an issue with not allowing certain fields in the query. Fix for https://github.com/CoderDojo/community-platform/issues/848