### PR TITLE
Fix for crashing sort by email in manage users list

### DIFF
--- a/lib/dojos.js
+++ b/lib/dojos.js
@@ -833,7 +833,8 @@ exports.register = function (server, options, next) {
           limit$: Joi.alternatives().try(Joi.number().integer().min(0), Joi.string()),
           skip$: Joi.number().integer().min(0).optional(),
           sort$: Joi.object().keys({
-            name: Joi.number().valid(-1).valid(1).optional()
+            name: Joi.number().valid(-1).valid(1).optional(),
+            email: Joi.number().valid(-1).valid(1).optional()
           })
         }})
       }


### PR DESCRIPTION
No issue open as such for this one. To reproduce:

  - As a manager click **My Dojos**
  - Click on **Users - Manage**
  - Sort by *name* works, but sort by ***email*** crashes as in https://github.com/CoderDojo/community-platform/issues/848