### PR TITLE
fix for utf-8 issues with translations

### DIFF
--- a/web/public/js/init-dashboard.js
+++ b/web/public/js/init-dashboard.js
@@ -430,8 +430,8 @@
       function($translateProvider) {
         $translateProvider.useUrlLoader('/locale/data?format=mf')
         .useCookieStorage()
-        .useSanitizeValueStrategy('sanitize')
-        .registerAvailableLanguageKeys(['en_US', 'it_IT'])
+        .useSanitizeValueStrategy('sanitizeParameters')
+        .registerAvailableLanguageKeys(['en_US', 'it_IT', 'de_DE', 'pt_PT'])
         .uniformLanguageTag('java')
         .determinePreferredLanguage()
         .fallbackLanguage('en_US');


### PR DESCRIPTION
This was a tricky one, because it only happens while the app is loading (anything translated within a template will be properly handled by the encoding in the main template, but this happens on app initialisation). It seems to be an issue with the library itself as explained [here](https://github.com/angular-translate/angular-translate/issues/1101#issuecomment-119300028). Thoughts?