### PR TITLE
Fix issue #724

### DIFF
--- a/web/public/css/dashboard.less
+++ b/web/public/css/dashboard.less
@@ -1122,6 +1122,10 @@ img.dojo-thumbnail {
 
 .intl-tel-input {
   display: inherit;
+
+  .flag-dropdown {
+    height: 34px; 
+  }
 }
 
 .cd-tooltip {


### PR DESCRIPTION
Dropdowns inner elements height is set to 100% thus being misplaced
when the height of the input field grows on displayed error message.

Set the height to a fixed value which prevents flag icon from getting
out of the input field area.

This resolves: https://github.com/CoderDojo/community-platform/issues/723