### PR TITLE
Fix the charter-page link not working correctly on the 404 page when logged in.

### DIFF
--- a/web/public/js/controllers/header-controller.js
+++ b/web/public/js/controllers/header-controller.js
@@ -15,6 +15,7 @@ function headerCtrl($window, $scope, $location, $state, intercomService, auth) {
     'dojo-list': '/dashboard/dojo-list',
     'manage-dojos': '/dashboard/manage-dojos',
     'stats':'/dashboard/stats',
+    'charter-page': '/dashboard/charter',
 
     //master states
     'home': '/',


### PR DESCRIPTION
It's set up in the dashboard controller, which is not pulled in for the 404, but setting it up in the base state still works. @machineperson actually figured this one out.

This is for issue https://github.com/CoderDojo/community-platform/issues/866