### PR TITLE
Fixed tooltip size

### DIFF
--- a/web/public/css/dashboard.less
+++ b/web/public/css/dashboard.less
@@ -115,7 +115,6 @@ label {
 
   .setup-dojo{
     padding: 20px;
-
     .validationMessage{
       width: 100%;
     }
@@ -292,6 +291,12 @@ label {
     position: relative;
     display: inline-block;
     transform: translateY(25%);
+
+    .tooltip {
+        .tooltip-inner {
+          width: 30em;
+        }
+    }
 
     .setup-dojo-info-btn {
       font-size: 2em;


### PR DESCRIPTION
Enforces a width of 30em for tooltips in the 'Setup your Dojo' form.
This fixes the tooltips being too tall and difficult to read.

Closes #749