### PR TITLE
Fixed 'y' in search bar for Firefox users

### DIFF
--- a/web/public/css/dashboard.less
+++ b/web/public/css/dashboard.less
@@ -475,7 +475,6 @@ label {
 
 #find-dojo-form #location {
   margin: 20px auto;
-  padding: 10px;
   width: 100%;
   text-align: center;
 }


### PR DESCRIPTION
This might win the prize for the most inconsequential commit ever pushed.

The 'y' is clipped for Firefox users. It's not clipped anymore.