### PR TITLE
Adding controller to manage application cancellations

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -122,9 +122,10 @@ exports.register = function (server, options, next) {
   }
 
   function deleteApplicationHandler (request, reply) {
+      
     var user = request.user;
-    var applicationId = request.payload.applicationId;
-    var eventId = request.payload.eventId;
+    var applicationId = request.params.applicationId;
+    var eventId = request.params.eventId;
 
     if (!applicationId || !eventId) return reply({ok: false, why: 'Application Id or Event Id missing'});
 
@@ -142,7 +143,7 @@ exports.register = function (server, options, next) {
   }
 
   function getEventById (request, eventId, done) {
-    seneca.act({
+    request.seneca.act({
       role: 'cd-events',
       cmd: 'getEvent',
       id: eventId

--- a/web/locale/en_US/messages.po
+++ b/web/locale/en_US/messages.po
@@ -2655,6 +2655,12 @@ msgstr "Cancelling Ticket"
 msgid "Ticket is being cancelled..."
 msgstr "Ticket is being cancelled..."
 
+msgid "Thank you for confirming you will not be in attendance; your application has now been cancelled."
+msgstr "Thank you for confirming you will not be in attendance; your application has now been cancelled."
+
+msgid "Invalid application cancellation link."
+msgstr "Invalid application cancellation link."
+
 msgid "No invites found"
 msgstr "No invites found"
 

--- a/web/locale/en_US/messages.po
+++ b/web/locale/en_US/messages.po
@@ -2649,8 +2649,11 @@ msgstr "Invitation successfully validated. Your ticket has been sent to your ema
 msgid "Invalid session invitation."
 msgstr "Invalid session invitation."
 
-msgid "Only the invited user can accept this invitation."
-msgstr "Only the invited user can accept this invitation."
+msgid "Cancelling Ticket"
+msgstr "Cancelling Ticket"
+
+msgid "Ticket is being cancelled..."
+msgstr "Ticket is being cancelled..."
 
 msgid "No invites found"
 msgstr "No invites found"

--- a/web/public/js/controllers/cancel-session-invite-controller.js
+++ b/web/public/js/controllers/cancel-session-invite-controller.js
@@ -1,0 +1,53 @@
+(function () {
+  'use strict';
+
+  function cancelSessionInviteCtrl($scope, $state, $stateParams, currentUser, $translate, alertService, usSpinnerService, cdEventsService) {
+    
+    usSpinnerService.spin('session-spinner');
+    
+    var applicationId = $stateParams.applicationId;
+    var ticketId = $stateParams.eventId;
+    currentUser = currentUser.data;
+
+    if (_.isEmpty(currentUser)) {
+        return $state.go('error-404-no-headers');
+    }
+
+    var application = {
+      id: applicationId,
+      ticketId: ticketId,
+      updateAction: 'delete',
+      deleted: true
+    };
+    
+    $scope.showAlertBanner = function (application, successMessage) {
+      return (application.status === 'approved' || application.attended || application.deleted) && successMessage !== undefined;
+    }
+
+    cdEventsService.bulkApplyApplications([application], function (applications) {   
+        
+        var successMessage = $translate.instant('Thank you for confirming you will not be in attendance; your ticket has now been cancelled.');
+             
+        if (_.isEmpty(applications)) {
+            return;
+        }
+        if ($scope.showAlertBanner(applications[0], successMessage)) {
+          alertService.showAlert(successMessage);
+        } else if (applications.ok === true) {
+            alertService.showAlert(successMessage);
+        } else {
+            alertService.showAlert($translate.instant(applications.why));
+        }
+        $state.go('home');
+        
+    }, function (err) {
+        if (err) {
+            console.error(err);
+            alertService.showError($translate.instant('Invalid ticket cancellation link.'));
+        }
+    })
+  }
+
+  angular.module('cpZenPlatform')
+    .controller('cancel-session-invite-controller', ['$scope', '$state', '$stateParams', 'currentUser', '$translate', 'alertService', 'usSpinnerService', 'cdEventsService', cancelSessionInviteCtrl]);
+})();

--- a/web/public/js/controllers/cancel-session-invite-controller.js
+++ b/web/public/js/controllers/cancel-session-invite-controller.js
@@ -6,45 +6,35 @@
     usSpinnerService.spin('session-spinner');
     
     var applicationId = $stateParams.applicationId;
-    var ticketId = $stateParams.eventId;
+    var eventId = $stateParams.eventId;
+    
     currentUser = currentUser.data;
-
     if (_.isEmpty(currentUser)) {
         return $state.go('error-404-no-headers');
     }
 
     var application = {
       id: applicationId,
-      ticketId: ticketId,
-      updateAction: 'delete',
-      deleted: true
+      eventId: eventId
     };
-    
-    $scope.showAlertBanner = function (application, successMessage) {
-      return (application.status === 'approved' || application.attended || application.deleted) && successMessage !== undefined;
-    }
 
-    cdEventsService.bulkApplyApplications([application], function (applications) {   
+    cdEventsService.removeApplicant(application, function (response) {   
         
-        var successMessage = $translate.instant('Thank you for confirming you will not be in attendance; your ticket has now been cancelled.');
+        var successMessage = $translate.instant('Thank you for confirming you will not be in attendance; your application has now been cancelled.');
              
-        if (_.isEmpty(applications)) {
-            return;
-        }
-        if ($scope.showAlertBanner(applications[0], successMessage)) {
+        if (response.ok === true) {
           alertService.showAlert(successMessage);
-        } else if (applications.ok === true) {
-            alertService.showAlert(successMessage);
         } else {
-            alertService.showAlert($translate.instant(applications.why));
+            alertService.showAlert($translate.instant(response.why));
         }
         $state.go('home');
         
     }, function (err) {
         if (err) {
             console.error(err);
-            alertService.showError($translate.instant('Invalid ticket cancellation link.'));
+            alertService.showError($translate.instant('Invalid application cancellation link.'));
         }
+        $state.go('home');
     })
   }
 

--- a/web/public/js/init-dashboard.js
+++ b/web/public/js/init-dashboard.js
@@ -401,6 +401,14 @@
           resolve: {
             currentUser: resolves.loggedInUser
           }
+        })
+        .state('cancel-session-invite', {
+            url:'/dashboard/cancel_session_invitation/:eventId/:applicationId',
+            controller:'cancel-session-invite-controller',
+            templateUrl:'/dojos/template/events/cancel-session-invite',
+            resolve: {
+                currentUser: resolves.loggedInUser
+            }
         });
       $urlRouterProvider.when('', '/');
       $urlRouterProvider.otherwise('/404');

--- a/web/public/templates/dojos/events/cancel-session-invite.dust
+++ b/web/public/templates/dojos/events/cancel-session-invite.dust
@@ -1,0 +1,5 @@
+<div class="cd-dashboard cd-color-3-underline">
+  <legend>{@i18n key="Cancelling Ticket"/}</legend>
+  <p>{@i18n key="Ticket is being cancelled..."/}</p>
+  <span spinner-key="session-spinner" us-spinner="{radius:30, width:8, length: 16}"></span>
+</div>

--- a/web/public/templates/layouts/dashboard.dust
+++ b/web/public/templates/layouts/dashboard.dust
@@ -165,6 +165,7 @@
     <script src="/js/controllers/session-modal-controller.js"></script>
     <script src="/js/controllers/session-invite-modal-controller.js"></script>
     <script src="/js/controllers/accept-session-invite-controller.js"></script>
+    <script src="/js/controllers/cancel-session-invite-controller.js"></script>
 
     <script src="/js/services/alert-service.js"></script>
     <script src="/js/services/spinner-service.js"></script>


### PR DESCRIPTION
This PR adds the angular controller and other necessary infrastructure to be able to handle the cancellation links from event application approval emails. Required for: https://github.com/CoderDojo/community-platform/issues/876