### PR TITLE
[894] - Multi select list are slow

### DIFF
--- a/web/bower.json
+++ b/web/bower.json
@@ -56,7 +56,7 @@
     "international-phone-number": "0.0.8",
     "ng-idle": "1.1.0",
     "angular-dynamic-locale": "0.1.27",
-    "angularjs-dropdown-multiselect": "https://github.com/david-cahill/angularjs-dropdown-multiselect.git#master",
+    "angularjs-dropdown-multiselect": "https://github.com/wardormeur/angularjs-dropdown-multiselect.git#master",
     "angular-tooltips": "0.1.23"
   },
   "devDependencies": {


### PR DESCRIPTION
Solves [CoderDojo/community-platform#894]
Reasons are the plugin attach events upon creation, instead of doing it upon opening
Library being not maintained anymore, we fork it and apply our patch :)
Commit which solved it is https://github.com/Wardormeur/angularjs-dropdown-multiselect/commit/b42421e69caaf7df52887adc31622d4464b17ff7
