### PR TITLE
Show session modal when on a public shared url and logged in

### DIFF
--- a/web/public/templates/layouts/master.dust
+++ b/web/public/templates/layouts/master.dust
@@ -157,6 +157,7 @@
     <script src="/js/controllers/accept-child-controller.js"></script>
     <script src="/js/controllers/dojos-map-controller.js"></script>
     <script src="/js/controllers/badges-dashboard-controller.js"></script>
+    <script src="/js/controllers/session-modal-controller.js"></script>
 
     <script src="/js/services/cd-api.js"></script>
     <script src="/js/services/cd-dojo-service.js"></script>


### PR DESCRIPTION
Fixes a bug which came in today when a user couldn't book a ticket because they were logged in and on

http://localhost:8000/dojo/x
instead of
http://localhost:8000/dashboard/dojo/x