### PR TITLE
Fix for CoderDojo/community-platform#932

### DIFF
--- a/web/public/js/controllers/dojo-event-form-controller.js
+++ b/web/public/js/controllers/dojo-event-form-controller.js
@@ -79,6 +79,9 @@
   }
 
   function fixEventTime(newTime, date){
+    if (!newTime) {
+      return date;
+    }
     newTime = moment.utc(newTime);
     date = moment.utc(date);
     return moment.utc([ date.get('year'), date.get('month'), date.date(),


### PR DESCRIPTION
Problem arose when you delete all the text from either input field on the time picker. The time picker returns null in this scenario, which when wrapped by moment results in "Invalid Date", which is from then on used as the basis for any time/date updates. The only way to kick out of this is to refresh the page.

I couldn't find any tests around this, but if there are some, point me in the right direction and I'll be happy to update them.