### PR TITLE
Fix header menu on iPad

### DIFF
--- a/web/public/css/global-menu.less
+++ b/web/public/css/global-menu.less
@@ -236,7 +236,7 @@
   }
 }
 
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 767px) {
 
   .cdgm-left {
     width: 20%;

--- a/web/public/css/header.less
+++ b/web/public/css/header.less
@@ -176,7 +176,7 @@ open > .dropdown-menu {
   }
 }
 
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 767px) {
   .cd-header {
     padding: 0;
   }


### PR DESCRIPTION
min-width and max-width are both inclusive, so both styles got applied 😀 