### PR TITLE
Remove stretching from cd-rounded-image for legacy images

### DIFF
--- a/web/public/js/directives/cd-rounded-image/style.less
+++ b/web/public/js/directives/cd-rounded-image/style.less
@@ -5,6 +5,10 @@
     border: none;
     cursor: pointer;
     z-index: 2;
+    object-fit: cover;
+    min-height: 200px;
+    min-width: 200px;
+
     &--full-width {
       width: 100%;
       border-radius: none;


### PR DESCRIPTION
screwed up commit from #962 