### PR TITLE
ui bugfix : recurring event for detail page, default space for buttons w/ icons

### DIFF
--- a/web/public/css/base/_button.less
+++ b/web/public/css/base/_button.less
@@ -10,8 +10,18 @@
 }
 
 .btn {
-  .fa:not(:only-child){
-    margin-right: 1em;
+  // This is a hack to ensure we have a minimal space when tehre is smme content, but a class should be applied to ensure a real spacing
+  .fa{
+    display: inline;
+    &:after {
+      content: ' '
+    }
+  }
+  // The class to apply to buttons with icons and text
+  &.icon {
+    .fa {
+      margin-right: 1em;
+    }
   }
 }
 .btn-block-xs {

--- a/web/public/js/directives/event/detail/index.js
+++ b/web/public/js/directives/event/detail/index.js
@@ -7,9 +7,16 @@ angular
         return {
           restrict: 'AE',
           templateUrl: '/directives/tpl/event/detail',
-          controller: ['$scope', 'cdEventsService', 'cdUsersService', '$translate', '$window', function($scope, cdEventsService, cdUsersService, $translate, $window) {
+          controller: ['$scope', 'cdEventsService', 'cdUsersService', '$translate', '$window', 'eventUtils',
+          function($scope, cdEventsService, cdUsersService, $translate, $window, eventUtils) {
             $scope.event.sessions = $scope.sessions;
-            $scope.event.formattedDate = moment.utc(_.head($scope.event.dates).startTime).format('Do MMMM YY');
+            $scope.event.isPast = eventUtils.isEventInPast(_.last($scope.event.dates));
+            $scope.event = eventUtils.getFormattedDates($scope.event);
+            if (!$scope.event.isPast && $scope.event.type === 'recurring') {
+              $scope.event.upcomingDates = eventUtils.getNextDates($scope.event.dates, $scope.event.formattedDates);
+              $scope.event.nextDate = moment.utc(_.first($scope.event.upcomingDates).startTime).format('Do MMMM YY');
+            }
+
             $scope.eventUserSelection = {};
             $scope.currentUser = {};
             var isParent = false;

--- a/web/public/js/directives/event/detail/style.less
+++ b/web/public/js/directives/event/detail/style.less
@@ -4,6 +4,9 @@
     h3 {
       display: inline-block;
     }
+    .h3 {
+      margin-left: 1em;
+    }
   }
   &__map-link {
     @media(min-width: @screen-sm-max){

--- a/web/public/js/directives/event/detail/template.dust
+++ b/web/public/js/directives/event/detail/template.dust
@@ -8,7 +8,12 @@
       <cd-share-event share-event="event"></cd-share-event>
       <span class="cd-event-detail__date col-xs-12">
         <i class="fa fa-clock-o"></i>
-        <h3><span ng-bind="::event.formattedDate"></span></h3>
+        <h3 ng-if="event.type === 'one-off'"><span ng-bind="::event.formattedDate"></span></h3>
+        <span ng-if="event.type === 'recurring'">
+          <h3><span ng-bind="::event.nextDate"></span></h3>
+          <span class="h3" ng-bind="::event.time"></span>
+          <p>(<i ng-bind="::event.formattedDate"></i>)</p>
+        </span>
       </span>
     </div>
     <div class="row">

--- a/web/public/js/directives/event/list/item/index.js
+++ b/web/public/js/directives/event/list/item/index.js
@@ -17,20 +17,8 @@ angular
             cdELI.event.isPast = eventUtils.isEventInPast(_.last(cdELI.event.dates));
             cdELI.event = eventUtils.getFormattedDates(cdELI.event);
             if (!cdELI.event.isPast && cdELI.event.type === 'recurring') {
-              cdELI.event.nextDate = void 0;
-              var nextDateIndex = void 0;
-              var eventIndex = 0;
-              while (eventIndex < cdELI.event.dates.length && _.isUndefined(nextDateIndex)) {
-                var date = cdELI.event.dates[eventIndex];
-                if (!eventUtils.isEventInPast(date)) {
-                  nextDateIndex = eventIndex;
-                }
-                eventIndex +=1;
-              }
-              if (nextDateIndex) {
-                cdELI.event.upcomingDates = cdELI.event.formattedDates.slice(nextDateIndex);
-                cdELI.event.nextDate = moment.utc(_.first(cdELI.event.upcomingDates).startTime).format('Do MMMM YY');
-              }
+              cdELI.event.upcomingDates = eventUtils.getNextDates(cdELI.event.dates, cdELI.event.formattedDates);
+              cdELI.event.nextDate = moment.utc(_.first(cdELI.event.upcomingDates).startTime).format('Do MMMM YY');
             }
             cdELI.datesExpanded = false;
             cdELI.goTo = function() {

--- a/web/public/js/directives/event/list/item/style.less
+++ b/web/public/js/directives/event/list/item/style.less
@@ -38,6 +38,7 @@
         padding: 2em;
       }
       &__date {
+        cursor: pointer;
       }
     }
   }

--- a/web/public/js/directives/event/list/item/template.dust
+++ b/web/public/js/directives/event/list/item/template.dust
@@ -27,7 +27,7 @@
       </div>
       <div ng-switch-default>
         <div class="cd-date__date h3" ng-bind="::cdELI.event.startDate | date : 'mediumDate'"></div>
-        <div class="cd-date__date h3" ng-bind="::cdELI.event.endDate | date : 'shortTime'"></div>
+        <div class="cd-date__date h3"><span ng-bind="::cdELI.event.startDate | date : 'HH:mm'"></span> - <span ng-bind="::cdELI.event.endDate | date : 'HH:mm'"></span></div>
       </div>
     </div>
     <div class="cd-event-list-item__link">

--- a/web/public/js/directives/event/list/item/template.dust
+++ b/web/public/js/directives/event/list/item/template.dust
@@ -12,18 +12,18 @@
   <div class="cd-date__content">
     <cd-share-event share-event="cdELI.event" class="pull-right cd-share-event" ng-if="!cdELI.isEmbedded"></cd-share-event>
     <div ng-switch="cdELI.event.type">
-      <div ng-switch-when="recurring">
-        <div>
-          <div class="cd-date__date h3" ng-bind="::cdELI.event.formattedDate"></div>
+      <div class="cd-date__content__date" ng-switch-when="recurring">
+        <div ng-click="cdELI.datesExpanded = !cdELI.datesExpanded">
+          <div class="h3" ng-bind="::cdELI.event.formattedDate"></div>
           <i class="fa fa-chevron-down pull-right" title="expand dates"
-            ng-click="cdELI.datesExpanded = !cdELI.datesExpanded" ng-class="cdELI.datesExpanded? 'fa-chevron-up': 'fa-chevron-down'"></i>
-          <div class="cd-date__date h5">
+             ng-class="cdELI.datesExpanded? 'fa-chevron-up': 'fa-chevron-down'"></i>
+          <div class="h5">
             {@i18n key="Next date:"/} <span ng-bind="::cdELI.event.nextDate | date : 'mediumDate'"></span>
           </div>
+          <ul ng-show="cdELI.datesExpanded"  class="list-unstyled">
+            <li ng-repeat="eventDate in cdELI.event.upcomingDates"> {{ eventDate }} </li>
+          </ul>
         </div>
-        <ul ng-show="cdELI.datesExpanded" class="list-unstyled">
-          <li ng-repeat="eventDate in cdELI.event.upcomingDates"> {{ eventDate }} </li>
-        </ul>
       </div>
       <div ng-switch-default>
         <div class="cd-date__date h3" ng-bind="::cdELI.event.startDate | date : 'mediumDate'"></div>

--- a/web/public/js/directives/event/share-event/style.less
+++ b/web/public/js/directives/event/share-event/style.less
@@ -13,7 +13,6 @@
         border-bottom: .1em solid @cd-light-gray;
         border-radius: inherit;
         .fa {
-          float: left;
           color: @cd-blue;
           padding: 0;
         }

--- a/web/public/js/services/event-utils.js
+++ b/web/public/js/services/event-utils.js
@@ -25,7 +25,7 @@ angular.module('cpZenPlatform').factory('eventUtils', ['$translate', function($t
       return formattedDates.slice(nextDateIndex);
     }
     // Congrats, you called this function upon an past event
-    return false;
+    return [];
   }
 
   eventUtils.getFormattedDates = function (event) {

--- a/web/public/js/services/event-utils.js
+++ b/web/public/js/services/event-utils.js
@@ -2,7 +2,7 @@
 
 angular.module('cpZenPlatform').factory('eventUtils', ['$translate', function($translate){
   var eventUtils = {};
-  eventUtils.isEventInPast = function(dateObj){
+  eventUtils.isEventInPast = function (dateObj) {
     var now = moment.utc();
     var eventUtcOffset = moment(dateObj.startTime).utcOffset();
     var start = moment.utc(dateObj.startTime).subtract(eventUtcOffset, 'minutes');
@@ -10,7 +10,25 @@ angular.module('cpZenPlatform').factory('eventUtils', ['$translate', function($t
     return now.isAfter(start);
   }
 
-  eventUtils.getFormattedDates = function(event) {
+  eventUtils.getNextDates = function (dates, formattedDates) {
+    var nextDateIndex = void 0;
+    var eventIndex = 0;
+    while (eventIndex < dates.length && _.isUndefined(nextDateIndex)) {
+      var date = dates[eventIndex];
+      if (!eventUtils.isEventInPast(date)) {
+        nextDateIndex = eventIndex;
+      }
+      eventIndex +=1;
+    }
+
+    if (nextDateIndex >= 0 && formattedDates) {
+      return formattedDates.slice(nextDateIndex);
+    }
+    // Congrats, you called this function upon an past event
+    return false;
+  }
+
+  eventUtils.getFormattedDates = function (event) {
     var utcOffset = moment().utcOffset();
 
     var startDate = moment.utc(_.head(event.dates).startTime).subtract(utcOffset, 'minutes').toDate();


### PR DESCRIPTION
Refactored code from last week to apply the same behavior to event detail (TODO : real UI, it's ugly AF, remove the popup plz)
Remove original catchall for .fa inside buttons to replace it with a hack that shouldn't impact anybody but leave it with a default space when the class is missing. TODO : add the real margin by adding the class to the necessary buttons