### PR TITLE
Fix a bug where an empty data response would return the whole promise

### DIFF
--- a/web/public/js/controllers/start-dojo-wizard-controller.js
+++ b/web/public/js/controllers/start-dojo-wizard-controller.js
@@ -92,7 +92,7 @@ function startDojoWizardCtrl($scope, $window, $state, $location, auth, alertServ
         currentStepInt = uncompletedDojoLead.currentStep + 1;
       }
 
-      if (currentStepInt === 4) {
+      if (currentStepInt === 5) { // cf ^desync, the db value is 4
         //Check if user has deleted the Dojo
         cdDojoService.find({dojoLeadId: uncompletedDojoLead.id}, function (response) {
           if (!_.isEmpty(response)) {

--- a/web/public/js/services/cd-api.js
+++ b/web/public/js/services/cd-api.js
@@ -48,8 +48,7 @@ angular.module('cpZenPlatform').service('cdApi', ['$http', function($http) {
     if (resolve) {
       fn()
       .then(function (response) {
-        var data = response.data && response.headers && response.config? response.data: response;
-        return resolve(data);
+        return resolve(_.has(response, 'data') && _.has(response, 'headers') && _.has(response, 'config') ? response.data : response);
       }, reject);
     } else {
       return fn();


### PR DESCRIPTION
when the api was used through a callback
because a condition over an empty string ("response.data") would return false, and hence the whole result instead of the empty string