### PR TITLE
Force ng-validator version to a specific commit

### DIFF
--- a/web/bower.json
+++ b/web/bower.json
@@ -27,7 +27,7 @@
     "ng-ckeditor": "https://github.com/david-cahill/ng-ckeditor.git#master",
     "ngstorage": "0.3.10",
     "spin.js": "2.3.2",
-    "tg-angular-validator": "https://github.com/turinggroup/angular-validator.git#master",
+    "tg-angular-validator": "https://github.com/turinggroup/angular-validator.git#v1.2.9",
     "js-marker-clusterer": "https://github.com/googlemaps/js-marker-clusterer.git#gh-pages",
     "angular-truncate": "*",
     "angular-wizard": "https://github.com/david-cahill/angular-wizard.git#master",


### PR DESCRIPTION
next ones enforce the fields to have a name, which we don't necessarly have right now