### PR TITLE
Add max image size to event descriptions

### DIFF
--- a/web/public/js/directives/event/detail/style.less
+++ b/web/public/js/directives/event/detail/style.less
@@ -13,6 +13,10 @@
       margin-top: -0.5em;
     }
   }
+  &__description img{
+    max-width: 100%;
+    max-height: 100%;
+  }
   .fa {
     margin-right: 0.5em;
   }

--- a/web/public/js/directives/event/detail/template.dust
+++ b/web/public/js/directives/event/detail/template.dust
@@ -26,7 +26,7 @@
         <button class="btn btn-secondary btn-block-xs" ng-click="goToGoogleMaps()" ng-show="event.position">{@i18n key="Location"/}</button>
       </span>
     </div>
-    <p ng-bind-html="::event.description"></p>
+    <p class="cd-event-detail__description" ng-bind-html="::event.description"></p>
 
     <cd-apply-for-event ></cd-apply-for-event>
   </div>

--- a/web/public/js/directives/event/list/item/style.less
+++ b/web/public/js/directives/event/list/item/style.less
@@ -9,6 +9,10 @@
     display: flex;
     height: inherit;
   }
+  &__description img {
+    max-width: 100%;
+    max-height: 100%;
+  }
   cd-share-event {
     display: inline-block;
     margin-top: 1em;

--- a/web/public/js/directives/event/list/item/template.dust
+++ b/web/public/js/directives/event/list/item/template.dust
@@ -4,7 +4,7 @@
     <p ng-bind="::cdELI.event.address"></p>
     <p ng-bind="::cdELI.event.city.nameWithHierarchy"></p>
   </div>
-  <div ng-bind-html="::cdELI.event.description">
+  <div class="cd-event-list-item__description" ng-bind-html="::cdELI.event.description">
   </div>
 </div>
 


### PR DESCRIPTION
Currently event description images can be added at any size. This
adds max-width / max-height to prevent images from being larger
than their parents.

Addresses CoderDojo/community-platform#1028

Before:
![image](https://cloud.githubusercontent.com/assets/831651/26020094/b5cd122a-3748-11e7-860b-767ce999b547.png)
After:
![image](https://cloud.githubusercontent.com/assets/831651/26020099/c30ef868-3748-11e7-885e-a6b40a585c86.png)
