### PR TITLE
Added job to install latest cp-zen-frontend and commit it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,23 @@ jobs:
       - run:
           name: Deploy to K8
           command: GIT_SHA1="$CIRCLE_SHA1" GIT_BRANCH="$CIRCLE_BRANCH" ./.circleci/kube.sh
+  update-frontend:
+    working_directory: ~/cp-zen-platform
+    docker:
+      - image: node:8.4
+    steps:
+      - checkout
+      - run:
+          name: Install latest cp-zen-frontend
+          command: yarn add cp-zen-frontend@"${CP_ZEN_FRONTEND_NPM_TAG}"
+      - run:
+          name: Commit and push updated package.json + yarn.lock
+          command: |
+            git config --global user.email "webteam@coderdojo.com"
+            git config --global user.name "CoderDojo Foundation"
+            git add package.json yarn.lock
+            git commit -m "[ci] Update frontend"
+            git push
 workflows:
   version: 2
   build-test-and-deploy:


### PR DESCRIPTION
Plan is to use [this](https://circleci.com/docs/2.0/api-job-trigger/) to trigger this specific job from a successful cp-zen-frontend build, and have CircleCI trigger a normal flow after the push so the correct cp-zen-frontend gets deployed.