### PR TITLE
Add SSH key fingerprint to use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
     docker:
       - image: node:8.4
     steps:
+      - add-ssh-keys:
+          fingerprints:
+            - "9d:83:fa:15:02:53:c4:e5:c4:5b:dc:1f:0a:90:82:5e"
       - checkout
       - run:
           name: Install latest cp-zen-frontend


### PR DESCRIPTION
Turns out we need to explicitly tell Circle which SSH key to use by referencing its fingerprint. Hopefully this is the last modification needed