### PR TITLE
Fix redirection to zen.cd.com with a valid token to automatically login

### DIFF
--- a/web/lib/plugins/auth.js
+++ b/web/lib/plugins/auth.js
@@ -52,6 +52,7 @@ exports.register = function (server, options, next) {
       clearInvalid: true,
       appendNext: true, // Redirect is not set here, but relative to the routes
       isSecure: process.env.NODE_ENV === 'production',
+      isSameSite: 'Lax',
       validateFunc: validateFunc(server),
     });
     next();


### PR DESCRIPTION
Changes cookie default from sameSite: Strict (default) to Lax
https://www.owasp.org/index.php/SameSite
Users will need to logout/in again to get a new cookie with Lax