### PR TITLE
Bubble up microservices HTTP errors to the frontend

### DIFF
--- a/test/lib/handlers/order.spec.js
+++ b/test/lib/handlers/order.spec.js
@@ -45,7 +45,7 @@ lab.describe('order handler', () => {
       sandbox.reset();
       done();
     });
-    lab.test('it should return the orders', (done) => {
+    lab.test('it should return the orders', async () => {
       Order.get.resolves([]);
       req = {
         params: {
@@ -55,19 +55,17 @@ lab.describe('order handler', () => {
           'query[eventId]': 'event1',
         },
       };
-      fn.get()[0](req, reply, () => {
-        expect(Order.get).to.have.been.calledWith({
-          'query[eventId]': 'event1',
-          'query[userId]': 'user1',
-        });
-        expect(reply).to.have.been.calledOnce;
-        expect(reply).to.have.been.calledWith([]);
-        expect(code).to.have.been.calledOnce;
-        expect(code).to.have.been.calledWith(200);
-        done();
+      await fn.get()[0](req, reply);
+      expect(Order.get).to.have.been.calledWith({
+        'query[eventId]': 'event1',
+        'query[userId]': 'user1',
       });
+      expect(reply).to.have.been.calledOnce;
+      expect(reply).to.have.been.calledWith([]);
+      expect(code).to.have.been.calledOnce;
+      expect(code).to.have.been.calledWith(200);
     });
-    lab.test('it should call cb on error', (done) => {
+    lab.test('it should call cb on error', async () => {
       const err = new Error('fake err');
       req = {
         params: {
@@ -78,16 +76,17 @@ lab.describe('order handler', () => {
         },
       };
       Order.get.rejects(err);
-      fn.get()[0](req, reply, (_err) => {
+      try {
+        await fn.get()[0](req, reply);
+      } catch(e) {
         expect(Order.get).to.have.been.calledWith({
           'query[eventId]': 'event1',
           'query[userId]': 'user1',
         });
-        expect(_err.message).to.equal('fake err');
+        expect(e.message).to.equal('fake err');
         // reply will be called by mastermind, in a boomified manner
         expect(reply).to.not.have.been.called;
-        done();
-      });
+      }
     });
   });
 

--- a/web/lib/handlers/order.js
+++ b/web/lib/handlers/order.js
@@ -1,4 +1,3 @@
-const { asyncify } = require('async');
 const mastermind = require('../mastermind');
 const Order = require('../models/order');
 const Email = require('../models/event-emails');
@@ -7,12 +6,12 @@ const Event = require('../models/event');
 const get = params => // eslint-disable-line no-unused-vars
   mastermind([
     // eslint-disable-next-line no-unused-vars
-    asyncify(async (req, reply, next) => {
+    async (req, reply, next) => {
       const userId = req.params.userId;
       const query = Object.assign({}, req.query, { 'query[userId]': userId });
       const orders = await Order.get(query);
       return reply(orders).code(200);
-    }),
+    },
   ]);
 
 const post = params => // eslint-disable-line no-unused-vars

--- a/web/lib/mastermind.js
+++ b/web/lib/mastermind.js
@@ -2,12 +2,18 @@ const { eachSeries } = require('async');
 const { partialRight } = require('lodash');
 const Boom = require('boom');
 
-const stepHandler = (step, cb, req, reply) => step(req, reply, cb);
+const stepHandler = async (step, cb, req, reply) => {
+  try {
+    return await step(req, reply, cb);
+  } catch(e) {
+    return cb(e);
+  }
+}
 
 const errorHandler = (err, reply) => {
   if (err) {
-    const { statusCode, message } = err;
-    return reply(Boom.boomify(err, { statusCode, message }));
+    const { statusCode } = err;
+    return reply(Boom.boomify(err, { statusCode }));
   }
 };
 // Note : to be investigated :


### PR DESCRIPTION
Errors from await fn used to be uncaught and simply stdout.
That makes hapi behave a bit more like a proxy and remove the need for asyncify