### PR TITLE
Allow empty string rather than converting it to undefined

### DIFF
--- a/web/api/validations/dojos.js
+++ b/web/api/validations/dojos.js
@@ -34,7 +34,7 @@ module.exports = function () {
       return Joi.alternatives().try(Joi.string().uri(), Joi.string());
     },
     optionalUri() {
-      return Joi.alternatives().try(joiValidator.uri(), Joi.string().empty(''), Joi.string().valid(null));
+      return Joi.alternatives().try(joiValidator.uri(), Joi.string().valid(null), Joi.string().allow(''));
     },
     country() {
       return Joi.object().keys({


### PR DESCRIPTION
That means resetting an url actually works instead of being stripped off by joi.
undefined for Seneca means no change :]