### PR TITLE
Fix users/orgs endpoint where the seneca call couldnt be proxied

### DIFF
--- a/web/api/organisations.js
+++ b/web/api/organisations.js
@@ -79,7 +79,7 @@ exports.register = function (server, eOptions, next) {
   }, {
     method: 'POST',
     path: `${options.basePath}/users/organisations`,
-    handler: handlers.actHandlerNeedsCdfAdmin('list', null, null, { ctrl: 'userOrg' }),
+    handler: handlers.actHandlerNeedsCdfAdmin('list', null, { ctrl: 'userOrg' }),
     config: {
       auth: auth.apiUser,
       description: 'Load organisation\'s users',


### PR DESCRIPTION
turns out handlerNeedsUser doesnt have the same def than handlerNeedsCdf