### PR TITLE
Remove the 'error handling' when viewing a user profile

### DIFF
--- a/web/public/js/controllers/user-profile-controller.js
+++ b/web/public/js/controllers/user-profile-controller.js
@@ -240,7 +240,7 @@ function cdUserProfileCtrl($scope, $rootScope, $state, $window, auth, cdUsersSer
 
 
   if(loggedInUser.data && $stateParams.userId){
-
+    // This function only works for parent and the user himself
     cdDojoService.dojosForUser($stateParams.userId, function (response) {
       $scope.dojos = response;
       if(_.isEmpty($scope.dojos)) {
@@ -253,7 +253,7 @@ function cdUserProfileCtrl($scope, $rootScope, $state, $window, auth, cdUsersSer
         findHighestUserType();
       }
     }, function (err) {
-      alertService.showError( $translate.instant('Error loading Dojos') + ' ' + err);
+      // When a dojo admin see the profile, he will not rely on this function
     });
 
     if ($scope.profile.children && $scope.profile.children.length > 0) {


### PR DESCRIPTION
dojos-for-user can't be validated without data masking: we let the API call fail without handling