### PR TITLE
Remove the +1 day to force looping

### DIFF
--- a/web/public/js/controllers/dojo-event-form-controller.js
+++ b/web/public/js/controllers/dojo-event-form-controller.js
@@ -3,7 +3,6 @@
   'use strict';
 
   function getEveryTargetWeekdayInDateRange(startDateTime, endDateTime, targetWeekday, eventType) {
-    endDateTime = moment.utc(endDateTime).add(1, 'days');
     var startTimeHour = moment(startDateTime.toDate()).hour();
     var startTimeMin = moment(startDateTime.toDate()).minute();
     var endTimeHour = moment(endDateTime.toDate()).hour();


### PR DESCRIPTION
Unecessary nowaydays as event can't have endTime < startTime
That fixes when an event was at day-1 from their DST date and the end time was changing due to that calculation