### PR TITLE
Fix vulnerable version of js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,5 +110,8 @@
     "sinon-chai": "^2.14.0",
     "supertest": "0.9.0"
   },
+  "resolutions": {
+    "hapi-swagger/**/js-yaml": "^3.13"
+  },
   "homepage": "https://github.com/CoderDojo/cp-zen-platform"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4264,9 +4264,17 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.1.0, js-yaml@^3.4.6, js-yaml@^3.9.1:
+js-yaml@^3.1.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.13, js-yaml@^3.4.6, js-yaml@^3.9.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Thanks god for the 'resolutions' block that allows us to bypass intermediate upgrades, at the risk of instability