### PR TITLE
Force redirection of events page from ng to vueJs by Hapi when possible

### DIFF
--- a/web/controllers/home/index.js
+++ b/web/controllers/home/index.js
@@ -108,14 +108,7 @@ module.exports = [
     method: 'GET',
     path: '/event/{eventId}',
     handler(request, reply) {
-      reply.view('index', request.app);
-    },
-    config: {
-      plugins: {
-        senecaPreloader: {
-          handler: 'seneca-event-preloader',
-        },
-      },
+      reply.redirect(`/events/${request.params.eventId}`);
     },
   },
 


### PR DESCRIPTION
The long redirect only happens on Firefox, Chrome is not affected by this issue as it doesn't seem to wait for the xhr (/languages) to end.
