### PR TITLE
Remove international phone validation library

### DIFF
--- a/web/bower.json
+++ b/web/bower.json
@@ -50,7 +50,6 @@
     "ng-slide-down": "1.2.0",
     "angular-i18n": "1.5.7",
     "angular-atomic-notify": "https://github.com/david-cahill/angular-atomic-notify.git#master",
-    "international-phone-number": "https://github.com/kidroca/international-phone-number.git#0.0.16p",
     "ng-idle": "1.2.2",
     "angular-dynamic-locale": "0.1.32",
     "angularjs-dropdown-multiselect": "https://github.com/CoderDojo/angularjs-dropdown-multiselect.git#1.6.0",

--- a/web/public/dependencies.json
+++ b/web/public/dependencies.json
@@ -51,7 +51,6 @@
   "./web/public/components/ng-slide-down/dist/ng-slide-down.min.js",
   "./web/public/components/angular-atomic-notify/src/angular-atomic-notify.js",
   "./web/public/components/intl-tel-input/build/js/intlTelInput.min.js",
-  "./web/public/components/international-phone-number/releases/international-phone-number.min.js",
   "./web/public/components/ng-idle/angular-idle.min.js",
   "./web/public/components/angular-dynamic-locale/tmhDynamicLocale.min.js",
   "./web/public/components/angularjs-dropdown-multiselect/dist/angularjs-dropdown-multiselect.min.js",

--- a/web/public/js/cp-zen-platform.js
+++ b/web/public/js/cp-zen-platform.js
@@ -1,5 +1,5 @@
 (function() {
-'use strict';
+  'use strict';
 
   angular.module('cpZenPlatform', [
     'pascalprecht.translate',
@@ -25,7 +25,6 @@
     'ngFileUpload',
     'ng-slide-down',
     'atomic-notify',
-    'internationalPhoneNumber',
     'ngIdle',
     'tmh.dynamicLocale',
     'angularjs-dropdown-multiselect',
@@ -33,6 +32,6 @@
     'ngGeolocation',
     'angular-google-analytics',
     'ngAria',
-    'ngAnimate'
+    'ngAnimate',
   ]);
 })();

--- a/web/public/js/directives/cd-start-dojo/champion/template.dust
+++ b/web/public/js/directives/cd-start-dojo/champion/template.dust
@@ -50,11 +50,9 @@
     <h3>{@i18n key="Contact details to help us verify your Dojo"/}</h3>
     <div class="form-group">
       <label for="phone">{@i18n key="Phone number"/}</label>
-      <input type="tel" name="phone" id="phone" autocomplete="off" class="form-control"
-        utils-script="/components/intl-tel-input/lib/libphonenumber/build/utils.js"
-         required cd-phone-validator international-phone-number ng-model="$ctrl.champion.phone">
+      <input type="tel" name="phone" id="phone" class="form-control" required ng-model="$ctrl.champion.phone">
         <div ng-messages="$ctrl.championForm.phone.$error" ng-show="$ctrl.championForm.phone.$touched && !$ctrl.championForm.phone.$valid">
-          <label class="control-label has-error validationMessage">{@i18n key="Telephone number is not valid"/}</label>
+          <label class="control-label has-error validationMessage">{@i18n key="Telephone Number is empty"/}</label>
         </div>
     </div>
     <div class="cd-sad-champion__social-network cd-simple-flex-grid">

--- a/web/public/templates/profiles/general-info.dust
+++ b/web/public/templates/profiles/general-info.dust
@@ -68,7 +68,7 @@
         <div class="form-group" ng-enter="noop()" ng-show="initialForm()">
           <label for="phone" class="col-sm-4 control-label">{@i18n key="Phone"/} </label>
           <div class="col-sm-8">
-            <input type="tel" autocomplete="off" utils-script="/components/intl-tel-input/lib/libphonenumber/build/utils.js" name="phone" international-phone-number class="form-control" id="phone" ng-model="profile.phone">
+            <input type="tel" name="phone" class="form-control" id="phone" ng-model="profile.phone">
           </div>
         </div>
 


### PR DESCRIPTION
The library was preventing valid numbers for Brazilian mobile phones
being added.
The library has not been updated in 2 years so unlikely to be fixed.

Removing phone number validation as trying to validate phone number
format is incredibly difficult with all the different international
formats possible.