### PR TITLE
Redirect to login page after PW reset

### DIFF
--- a/web/public/js/controllers/login-controller.js
+++ b/web/public/js/controllers/login-controller.js
@@ -268,8 +268,7 @@ function loginCtrl($state, $stateParams, $scope, $rootScope, $location, $window,
       repeat:$scope.reset.confirmNewPassword
     }, function (response) {
       if(response.ok) {
-        alertService.showAlert($translate.instant('Successfully updated password.'));
-        $state.go('login');
+        $window.location.href = 'login?pwr=true';
       } else {
         alertService.showError($translate.instant('Error') + ':' + $translate.instant(response.why));
       }


### PR DESCRIPTION
The angular app doesn't seem to be redirecting to the vue page correctly for password resets.
Passes a query string to let the vue app know the password was reset so
it can display a success message.