### PR TITLE
removing exports as they no longer work with latest docker-compose

### DIFF
--- a/web/config/development.env
+++ b/web/config/development.env
@@ -1,4 +1,4 @@
-export EVENTS_SERVICE=events2
-export EMAIL_SERVICE=email
-export USERS_SERVICE=users
-export CLUBS_SERVICE=clubs
+EVENTS_SERVICE=events2
+EMAIL_SERVICE=email
+USERS_SERVICE=users
+CLUBS_SERVICE=clubs


### PR DESCRIPTION
This is a small fix for an issue that recently popped up due to a change in docker-compose:
https://github.com/docker/compose/issues/6511

Basically, "export var=val" is no longer allowed in  .env files. It used to work, but mostly by accident. The proper syntax is "var=val"

My initial report of this issue can be found here: https://github.com/CoderDojo/cp-local-development/issues/83