### PR TITLE
Oauth flow error handling

### DIFF
--- a/web/config/options.js
+++ b/web/config/options.js
@@ -27,6 +27,10 @@ module.exports = {
   },
 
   hapi: {
+    debug:
+      process.env.NODE_ENV === 'development'
+        ? { log: ['error'], request: ['error'] }
+        : false,
     connections: {
       routes: {
         security: {


### PR DESCRIPTION
- Oauth user error display - use new error display query param in zen frontend
- Error logging on local dev (currently too noisy to turn on in prod)
- Temporarily verbose client side messages while oauth flow is private

Relates to item in stage 2 of https://github.com/CoderDojo/community-platform/issues/1290