### PR TITLE
Require Accept Terms & Conditions

### DIFF
--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -66,7 +66,7 @@ function getZenRegisterPayload(decodedIdToken) {
       email: decodedIdToken.email,
       password: rpiZenAccountPassword,
       // TODO: prompt for zen conditions acceptance
-      termsConditionsAccepted: true,
+      termsConditionsAccepted: false,
       // TODO: determine approach for o13 and u13 user types reg flows
       initUserType: { name: 'parent-guardian' },
       raspberryId: decodedIdToken.uuid,

--- a/web/public/js/directives/user/cd-profile/edit/style.less
+++ b/web/public/js/directives/user/cd-profile/edit/style.less
@@ -3,6 +3,10 @@
     padding-top: 7px;
     height: 20px;
   }
+  /* hides unwanted required error, can't figure out where it coes from! */
+  .terms-conditions label.has-error:not(#terms-required-error) {
+    display: none;
+  }
   &__general-info {
     &-linkedin, &-twitter {
       & .has-error .input-group-addon {

--- a/web/public/templates/profiles/general-info.dust
+++ b/web/public/templates/profiles/general-info.dust
@@ -209,6 +209,17 @@
             <label for="mailingList">{@i18n key="Subscribe to newsletter"/} </label>
           </div>
         </div>
+        <div class="margin-left-35-percent">
+          <div class="checkbox terms-conditions">
+            <input type="checkbox" name="termsConditionsAccepted" ng-class="{'has-error': forms.generalInfoForm.$submitted && forms.generalInfoForm.termsConditionsAccepted.$error.required}" ng-model="profile.user.termsConditionsAccepted" required id="termsAndConditionsCheckbox">
+            <label for="termsAndConditionsCheckbox">{@i18n key="I have read and accept the <a ui-sref=\"terms-and-conditions\" target=\"_blank\"><b>Terms and Conditions here</b></a>"/}
+            </label>
+            <div>
+              <label class="control-label has-error validationMessage" id="terms-required-error"
+              ng-show="forms.generalInfoForm.$submitted && forms.generalInfoForm.termsConditionsAccepted.$error.required">{@i18n key="You must accept the Terms and Conditions"/}</label>
+            </div>
+          </div>
+        </div>
 
         <h4 ng-if="abilityToAddChildren()" ng-show="afterForm()" >{@i18n key="Got a child? Add them below"/}</h4>
         <div ng-show="afterForm()">


### PR DESCRIPTION
- Add accept terms & conditions to profile edit as required field
- Make the accept t&c's false for new pi accounts

There is an existing mechanism in the angular app that redirects user to edit profile page if all required fields haven't been filled (requiredFieldsComplete = false). Accept T&C's is a required field so by adding it to the edit profile page, the user will be directed there after signing up and can accept.

The equivalient requiredFieldsComplete doesn't yet exist in the vue app.