### PR TITLE
Use auto instead of global raspberry pword for login

### DIFF
--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -207,7 +207,7 @@ function handleCb(request, reply) {
         role: 'user',
         cmd: 'login',
         email: email,
-        password: rpiZenAccountPassword,
+        auto: true,
       },
       (err, res) => {
         if (err) {


### PR DESCRIPTION
The global password will still be used for the auto registration flow on new accounts created by an unknown email coming through from rasperry pi.

Pre complete switchover, this puts us in a spot where a raspberry linked user could still log in with password but would be pinned at a screen telling them their account is raspberry linked and they need to go through there to log in.