### PR TITLE
RPI -> ZEN Account type redirect

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -19,7 +19,7 @@ lab.experiment('setup server', () => {
   });
   lab.describe('should load plugins', () => {
     lab.test('to be always the same length', done => {
-      let expectedQty = 36;
+      let expectedQty = 37;
       // Set up good
       if (
         process.env.HAPI_DEBUG === 'true' ||

--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -74,9 +74,7 @@ function getZenRegisterPayload(decodedIdToken, isAttendee) {
       lastName: '',
       email: decodedIdToken.email,
       password: rpiZenAccountPassword,
-      // TODO: prompt for zen conditions acceptance
-      termsConditionsAccepted: false,
-      // TODO: determine approach for o13 and u13 user types reg flows
+      termsConditionsAccepted: true,
       initUserType: { name: isAttendee ? 'attendee-o13' : 'parent-guardian' },
       raspberryId: decodedIdToken.uuid,
       nick: decodedIdToken.email,

--- a/web/index.js
+++ b/web/index.js
@@ -9,6 +9,7 @@ const hapiEtags = require('hapi-etags');
 const ip2country = require('hapi-ip2country-plugin');
 const vision = require('./lib/plugins/vision');
 const cdAuth = require('./lib/plugins/auth');
+const rpiAuth = require('./lib/plugins/rpi-auth');
 const scooterAndBlankie = require('./lib/plugins/scooterAndBlankie');
 const controllers = require('./controllers');
 const senecaPreloaders = require('./lib/plugins/seneca-preloader-dustjs');
@@ -87,6 +88,7 @@ exports.start = () => {
           handlers: ['seneca-event-preloader', 'seneca-dojo-preloader'],
         },
       },
+      { register: rpiAuth },
       { register: controllers },
       { register: cpZenFrontend },
       { register: sitemap },

--- a/web/lib/plugins/rpi-auth.js
+++ b/web/lib/plugins/rpi-auth.js
@@ -1,0 +1,10 @@
+const { registerRpiStateCookie } = require('../rpi-auth');
+
+exports.register = (server, options, next) => {
+  registerRpiStateCookie(server);
+  next();
+};
+
+exports.register.attributes = {
+  name: 'cd-rpi-auth',
+};

--- a/web/lib/rpi-auth.js
+++ b/web/lib/rpi-auth.js
@@ -78,9 +78,17 @@ function decodeIdToken(idToken) {
   return jwt.decode(idToken);
 }
 
+function verifyIdTokenPayload(idTokenPayload) {
+  const epochSeconds = Math.floor(new Date().getTime() / 1000);
+  const isIssueTimeValid = idTokenPayload.iat <= epochSeconds;
+  const isNotExpired = idTokenPayload.exp > epochSeconds;
+  const isIssuerValid = idTokenPayload.iss === process.env.RPI_AUTH_URL;
+  return isIssueTimeValid && isNotExpired && isIssuerValid;
+}
+
 function registerRpiStateCookie(server) {
   server.state('rpi-state', {
-    ttl: 600000, // 10 minutes
+    ttl: 10 * 60 * 1000, // 10 minutes
     isSecure: process.env.NODE_ENV === 'production',
     isHttpOnly: true,
     isSameSite: 'Lax',
@@ -124,4 +132,5 @@ module.exports = {
   getRpiStateCookie,
   clearRpiStateCookie,
   getAccountTypeRedirectUrl,
+  verifyIdTokenPayload,
 };

--- a/web/lib/rpi-auth.js
+++ b/web/lib/rpi-auth.js
@@ -78,6 +78,27 @@ function decodeIdToken(idToken) {
   return jwt.decode(idToken);
 }
 
+function registerRpiStateCookie(server) {
+  server.state('rpi-state', {
+    ttl: 600000,
+    isSecure: process.env.NODE_ENV === 'production',
+    isHttpOnly: true,
+    isSameSite: 'Lax',
+    encoding: 'none',
+    clearInvalid: true,
+    strictHeader: true,
+    path: '/',
+  });
+}
+
+function setRpiStateCookie(reply, state) {
+  reply.state('rpi-state', state);
+}
+
+function getRpiStateCookie(request) {
+  return request.state['rpi-state'];
+}
+
 module.exports = {
   decodeIdToken,
   getRedirectUri,
@@ -86,4 +107,7 @@ module.exports = {
   getLogoutRedirectUri,
   rpiZenAccountPassword,
   getEditRedirectUri,
+  registerRpiStateCookie,
+  setRpiStateCookie,
+  getRpiStateCookie,
 };


### PR DESCRIPTION
Associated frontend PR Must be merged first - https://github.com/CoderDojo/cp-zen-frontend/pull/287

**What**
When a new user arrives from my raspberry pi, before creating a zen account for them, direct them to a page to choose an attendee or parent/guardian type account. Resume account creation after the choice has been made

**Why**
On the existing zen login flow, the user age is used for determining account type (under 18 = attendee). We no longer collect date of birth so the decision must be made another way. An explicit choice is being offered for now.

**How**
- Expect a `type` query param at the `/rpi/cb` route. if type is `attendee` make attendee account, otherwise paarent/guardian.
- If `type` query param is not found, redirect user to `/account-type` page which will redirect back to `/rpi/cb/` with type param when finished.
- Implement oauth2 [state parameter](https://auth0.com/docs/protocols/oauth2/oauth-state) to protect against CSRF attacks and track users through auth process.
- Add short lived (10 minutes) cookie to link user to rpi oauth id token during account-type selection

Partially resolves https://github.com/RaspberryPiFoundation/profile/issues/1048