### PR TITLE
Rpi auth nav link changes

### DIFF
--- a/web/public/js/controllers/login-controller.js
+++ b/web/public/js/controllers/login-controller.js
@@ -16,18 +16,18 @@ function loginCtrl($state, $stateParams, $scope, $rootScope, $location, $window,
     $scope.redirect = $location.search().redirect;
   }
 
-  var profileAuthFlag = $window.localStorage.getItem('profileAuth');
+  var rpiAuthFlag = $window.localStorage.getItem('rpiAuth');
 
-  if (profileAuthFlag === 'true') {
-    var profileAuthPath = $window.location.pathname === '/register/user' ? '/rpi/register' : '/rpi/login';
-    profileAuthPath += '?origin=' + encodeURIComponent($window.location.pathname);
+  if (rpiAuthFlag === 'true') {
+    var rpiAuthPath = $window.location.pathname === '/register/user' ? '/rpi/register' : '/rpi/login';
+    rpiAuthPath += '?origin=' + encodeURIComponent($window.location.pathname);
     if ($scope.redirect) {
-      profileAuthPath += '&redirect=' + encodeURIComponent($scope.redirect);
+      rpiAuthPath += '&redirect=' + encodeURIComponent($scope.redirect);
     }
     if ($state.current && $state.current.name) {
-      profileAuthPath += '&appState=' + encodeURIComponent($state.current.name);
+      rpiAuthPath += '&appState=' + encodeURIComponent($state.current.name);
     }
-    return $window.location.href = profileAuthPath;
+    return $window.location.href = rpiAuthPath;
   }
 
   var msgmap = {

--- a/web/public/js/services/auth-service.js
+++ b/web/public/js/services/auth-service.js
@@ -18,8 +18,8 @@ angular.module('cpZenPlatform').service('auth', ['$http', '$q', '$window', 'cdAp
     },
 
     logout: function(win,fail){
-      var profileAuthFlag = $window.localStorage.getItem('profileAuth');
-      if (profileAuthFlag === 'true') {
+      var rpiAuthFlag = $window.localStorage.getItem('rpiAuth');
+      if (rpiAuthFlag === 'true') {
         $window.location.href = '/rpi/logout'
       } else {
         $http({method:'POST', url: '/api/2.0/users/logout', data:{}, cache:false}).

--- a/web/public/templates/common/header.dust
+++ b/web/public/templates/common/header.dust
@@ -8,8 +8,8 @@
       <div class="cd-menu__nav-right">
         <a class="emphasis" href="https://help.coderdojo.com">{@i18n key="Help"/}</a>
         <div class="cd-menu__account">
-          <a href="/register/user">{@i18n key="Register"/}</a>
-          <a href="/login">{@i18n key="Login"/}</a>
+          <a href="/register/user" id="register-anchor">{@i18n key="Register"/}</a>
+          <a href="/login" id="login-anchor">{@i18n key="Login"/}</a>
         </div>
         <div class="cd-menu__profile">
           <div class="cd-menu__profile-pic"></div>
@@ -138,4 +138,12 @@
     </div>
   </nav>
   <ng-atomic-notify></ng-atomic-notify>
+  <!-- TODO replace in header when full migration is run! -->
+  <script>
+    if (window.localStorage.getItem('rpiAuth') === 'true') {
+      document.querySelector('a[href="/login"]').href = "/rpi/login";
+      document.querySelector('a[href="/logout"]').href = "/rpi/logout";
+      document.querySelector('a[href="/register/user"]').href = "/rpi/register";
+    }
+  </script>
 </header>


### PR DESCRIPTION
issue: https://github.com/RaspberryPiFoundation/profile/issues/1060

- Check `rpiAuth` local storage flag on load in browser and change nav auth links to rpi if necessary.
- Rename existing auth flag references to new `rpiAuth` name.

NOTE: Messy auth controller redirect logic should hopefully never be reached but is left in incase user goes directly to a legacy auth URL with the `rpiAuth` flag on.

Related zen-frontend PR: https://github.com/CoderDojo/cp-zen-frontend/pull/296