### PR TITLE
Change DMAH link to point to new learn hub

### DIFF
--- a/web/public/js/directives/cd-start-dojo/template.dust
+++ b/web/public/js/directives/cd-start-dojo/template.dust
@@ -1,6 +1,6 @@
 <div class="cd-banner">
-  <p>{@i18n key="Thank you for your interest in joining the CoderDojo community!"/}</p>
-  <p>{@i18n key="Due to the coronavirus pandemic, we have paused the Dojo verification process."/}</p>
+  <p>{@i18n key="Thank you for your interest in joining the CoderDojo community!"/}
+     {@i18n key="Due to the coronavirus pandemic, we have paused the Dojo verification process."/}</p>
   <p>{@i18n key="In the meantime, we’re providing exciting opportunities for young people, parents, volunteers, and educators to get creative with tech through"/} <a class="cd-banner-link" href="https://www.raspberrypi.org/learn/?utm_source=coderdojo&utm_medium=covid-banner&utm_campaign=dmah">{@i18n key="Digital Making at Home"/}</a> {@i18n key="from the Raspberry Pi Foundation."/}
   </p>
 </div>

--- a/web/public/js/directives/cd-start-dojo/template.dust
+++ b/web/public/js/directives/cd-start-dojo/template.dust
@@ -1,7 +1,7 @@
 <div class="cd-banner">
   <p>{@i18n key="Thank you for your interest in joining the CoderDojo community!"/}</p>
   <p>{@i18n key="Due to the coronavirus pandemic, we have paused the Dojo verification process."/}</p>
-  <p>{@i18n key="In the meantime, we’re providing exciting opportunities for young people, parents, volunteers, and educators to get creative with tech through"/} <a class="cd-banner-link" href="https://www.raspberrypi.org/at-home/?utm_source=coderdojo&utm_medium=covid-banner&utm_campaign=dmah">{@i18n key="Digital Making at Home"/}</a> {@i18n key="from the Raspberry Pi Foundation."/}
+  <p>{@i18n key="In the meantime, we’re providing exciting opportunities for young people, parents, volunteers, and educators to get creative with tech through"/} <a class="cd-banner-link" href="https://www.raspberrypi.org/learn/?utm_source=coderdojo&utm_medium=covid-banner&utm_campaign=dmah">{@i18n key="Digital Making at Home"/}</a> {@i18n key="from the Raspberry Pi Foundation."/}
   </p>
 </div>
 <div ng-show="$ctrl.loading" style="height: 300px; position: relative;">


### PR DESCRIPTION
Following launch of the new learn hub on raspberrypi.org.

I've not added the bit about registering interest here, as this is the start-dojo page.