### PR TITLE
Add maintenance page

### DIFF
--- a/web/controllers/home/index.js
+++ b/web/controllers/home/index.js
@@ -252,4 +252,20 @@ module.exports = [
       reply.view('accounts/reset_password', request.app);
     },
   },
+
+  {
+    method: 'GET',
+    path: '/maintenance',
+    handler(request, reply) {
+      reply.view('index', request.app);
+    },
+  },
+
+  {
+    method: 'GET',
+    path: '/templates/maintenance',
+    handler(request, reply) {
+      reply.view('maintenance/maintenance', request.app);
+    },
+  },
 ];

--- a/web/public/js/controllers/maintenance-controller.js
+++ b/web/public/js/controllers/maintenance-controller.js
@@ -1,0 +1,8 @@
+ 'use strict';
+
+function cdMaintenanceCtrl($scope) {
+
+}
+
+angular.module('cpZenPlatform')
+    .controller('maintenance', ['$scope', cdMaintenanceCtrl]);

--- a/web/public/js/init-master.js
+++ b/web/public/js/init-master.js
@@ -941,7 +941,15 @@
           params: {
             pageTitle: 'Page not found',
           }
-        });
+        })
+        .state("maintenance", {
+          url: "/maintenance",
+          templateUrl: '/templates/maintenance',
+          controller: 'maintenance-controller',
+          params: {
+            pageTitle: 'Undergoing maintenance',
+          }
+        })
       $urlRouterProvider.when('', '/');
       $urlRouterProvider.when('/register?referer', ['$state', '$location', function($state, $location) {
         // For some reasons, abstract states don't capture the query params

--- a/web/public/js/services/translation-keys.js
+++ b/web/public/js/services/translation-keys.js
@@ -1050,7 +1050,9 @@ angular.module('cpZenPlatform')
       "Due to the coronavirus pandemic, we have paused the Dojo verification process.": "Due to the coronavirus pandemic, we have paused the Dojo verification process.",
       "In the meantime, we’re providing exciting opportunities for young people, parents, volunteers, and educators to get creative with tech through": "In the meantime, we’re providing exciting opportunities for young people, parents, volunteers, and educators to get creative with tech through",
       "Digital Making at Home": "Digital Making at Home",
-      "from the Raspberry Pi Foundation.": "from the Raspberry Pi Foundation."
+      "from the Raspberry Pi Foundation.": "from the Raspberry Pi Foundation.",
+      "The site is currently undergoing maintenance.": "The site is currently undergoing maintenance.",
+      "Please be paitent, the site will be available again shortly.": "Please be paitent, the site will be available again shortly."
     };
   })
   .filter('translateFromKey', ['$translate', 'translationKeys', function ($translate, translationKeys) {

--- a/web/public/templates/maintenance/maintenance.dust
+++ b/web/public/templates/maintenance/maintenance.dust
@@ -1,0 +1,9 @@
+<div class="container">
+  <div class="container">
+    <div class="col-xs-12 col-sm-10 col-sm-offset-1 text-center page-not-found">
+      <div class="ninja"></div>
+      <p>{@i18n key="The site is currently undergoing maintenance."/}</p>
+      <p>{@i18n key="Please be paitent, the site will be available again shortly."/}</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Add a maintenance page that we can use during the account migration process.

We can use cloudflare page rules to send people away from the login and register pages while the migration runs so they view this page instead.

Layout is copied from the 404 page.

<img width="1298" alt="Screenshot 2020-05-22 at 13 53 22" src="https://user-images.githubusercontent.com/6632347/82670003-4d758000-9c34-11ea-9c42-048c0398fa7b.png">
