### PR TITLE
Remove instruction to install latest packages in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM node:8-alpine
 MAINTAINER butlerx <butlerx@notthe.cloud>
-ARG DEP_VERSION=latest
 RUN apk add --update git make gcc g++ python && \
     mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . /usr/src/app/
 RUN yarn && \
-    yarn add cp-zen-frontend@"$DEP_VERSION" cp-translations@"$DEP_VERSION" && \
     node_modules/.bin/bower install --allow-root && \
     yarn build && \
     apk del make gcc g++ python && \


### PR DESCRIPTION
Installing the latest package at this point is unecessary (there is a
mechanism in place to do so if we need it).

It also breaks when the latest version of a package contains work that
isn't meant to be pushed live yet.