### PR TITLE
54: Allow Date of Birth to be empty when booking an event.

### DIFF
--- a/web/api/events.js
+++ b/web/api/events.js
@@ -359,7 +359,7 @@ exports.register = function(server, eOptions, next) {
                 // Update
                 attendance: Joi.array(),
                 created: Joi.date(),
-                dateOfBirth: Joi.date(),
+                dateOfBirth: Joi.date().allow(null),
                 deleted: Joi.boolean(),
                 orderId: Joi.string()
                   .guid()

--- a/web/api/profiles.js
+++ b/web/api/profiles.js
@@ -78,7 +78,7 @@ exports.register = function(server, eOptions, next) {
                 .guid()
                 .required(),
               country: Joi.object().allow(null),
-              dob: Joi.date().required(),
+              dob: Joi.date().allow(null),
               email: Joi.string()
                 .email()
                 .required(),

--- a/web/api/validations/orders.js
+++ b/web/api/validations/orders.js
@@ -8,7 +8,7 @@ const definitions = {
     Joi.object().keys({
       id: Joi.string().guid(),
       name: Joi.string(),
-      dateOfBirth: Joi.date(),
+      dateOfBirth: Joi.date().allow(null),
       eventId: Joi.string().guid(),
       userId: Joi.string().guid(),
       sessionId: Joi.string().guid(),


### PR DESCRIPTION
Fixes: https://github.com/RaspberryPiFoundation/digital-core/issues/54

Add allow(null) to Joi validations for API calls.

- TODO: Check if the dob validation needs changing for creating / updating a youth profile
https://github.com/CoderDojo/cp-zen-platform/blob/master/web/api/profiles.js#L144
https://github.com/CoderDojo/cp-zen-platform/blob/master/web/api/profiles.js#L181

(I don't think so because when we add / update children, we enter their D.O.B. in the UI)