### PR TITLE
Force long URLs to wrap in admin tables

### DIFF
--- a/web/public/js/directives/dojo/lead/style.less
+++ b/web/public/js/directives/dojo/lead/style.less
@@ -34,6 +34,18 @@
               @cd-very-light-grey 20px
             );
           }
+
+          a {
+            overflow-wrap: break-word;
+            word-wrap: break-word;
+            -ms-word-break: break-all;
+            word-break: break-all;
+            word-break: break-word; /* for Webkit's benefit */
+            -ms-hyphens: auto;
+            -moz-hyphens: auto;
+            -webkit-hyphens: auto;
+            hyphens: auto;
+          }
         }
       }
     }


### PR DESCRIPTION
When viewing leads in the admin dashboard, long URLs don't wrap and cause all sorts of fun things to happen to the table layout.

As far as I understand, the build process will generate the relevant `app.css` file.