### PR TITLE
Remove community links

### DIFF
--- a/web/public/templates/common/header.dust
+++ b/web/public/templates/common/header.dust
@@ -41,9 +41,6 @@
           {@i18n key="Community"/}
           <i class="cd-menu__dropdown-icon fa fa-chevron-down"></i>
           <ul>
-            <li><a href="/badges">{@i18n key="Badges"/}</a></li>
-            <li><a href="https://forums.coderdojo.com/">{@i18n key="Forums"/}</a></li>
-            <li><a href="https://ninjaforums.coderdojo.com/">{@i18n key="Ninja Forums"/}</a></li>
             <li><a href="http://coolestprojects.org/">Coolest Projects</a></li>
           </ul>
         </span>

--- a/web/public/templates/common/header.dust
+++ b/web/public/templates/common/header.dust
@@ -125,9 +125,6 @@
                   <span>{@i18n key="Community"/}</span>
                 </div>
                 <ul class="cd-menu__content-block">
-                  <li><a href="https://coderdojo.com/community/badges/">{@i18n key="Badges"/}</a></li>
-                  <li><a href="https://forums.coderdojo.com/">{@i18n key="Forums"/}</a></li>
-                  <li><a href="https://ninjaforums.coderdojo.com/">{@i18n key="Ninja Forums"/}</a></li>
                   <li><a href="http://coolestprojects.org/">Coolest Projects</a></li>
                 </ul>
               </div>


### PR DESCRIPTION
- Related to: https://github.com/RaspberryPiFoundation/digital-foundation/issues/368
- Removes community links as specified in the [GSHEET](https://docs.google.com/spreadsheets/d/1BWkOPVbefZo-7Gea9IIkToF7mMS1neVzFOyEFlJ3BjA/edit#gid=1012642429)

![Screenshot 2022-09-26 at 15 32 25](https://user-images.githubusercontent.com/14238047/192303527-5e2a1b6d-baa7-4ea8-a17d-28b80e59e2fa.png)
