### PR TITLE
Add force_signup param to register path

### DIFF
--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -6,7 +6,6 @@ const Boom = require('boom');
 const { URLSearchParams } = require('url');
 const {
   getRedirectUri,
-  getRegisterRedirectUri,
   getEditRedirectUri,
   getLogoutRedirectUri,
   getIdToken,

--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -25,9 +25,7 @@ function getErrorRedirectUrl(message = oauthErrorMessage) {
   return `/?${errorUrlQueryParams}`;
 }
 
-function handleRPILogin(request, reply) {
-  let redirectQueryParams = {};
-  if (request.query.mgrt) redirectQueryParams = { mgrt: request.query.mgrt };
+function handleRPILogin(request, reply, redirectQueryParams = {}) {
   const state = crypto.randomBytes(20).toString('hex');
   setRpiStateCookie(reply, { state });
   const redirectUri = getRedirectUri(state, redirectQueryParams);
@@ -56,14 +54,8 @@ function handleRPIRegister(request, reply) {
   if (session && session.token) {
     return reply.redirect('/');
   }
-  
-  let redirectQueryParams = {};
-  if (request.query.mgrt) redirectQueryParams = { mgrt: request.query.mgrt};
-  redirectQueryParams['login_options'] = 'force_signup';
-  const state = crypto.randomBytes(20).toString('hex');
-  setRpiStateCookie(reply, { state });
-  const redirectUri = getRedirectUri(state, redirectQueryParams);
-  reply.redirect(redirectUri);
+
+  handleRPILogin(request, reply, { login_options: 'force_signup' })
 }
 
 function handleRPIEdit(request, reply) {

--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -57,7 +57,13 @@ function handleRPIRegister(request, reply) {
   if (session && session.token) {
     return reply.redirect('/');
   }
-  const redirectUri = getRegisterRedirectUri();
+  
+  let redirectQueryParams = {};
+  if (request.query.mgrt) redirectQueryParams = { mgrt: request.query.mgrt};
+  redirectQueryParams['login_options'] = 'force_signup';
+  const state = crypto.randomBytes(20).toString('hex');
+  setRpiStateCookie(reply, { state });
+  const redirectUri = getRedirectUri(state, redirectQueryParams);
   reply.redirect(redirectUri);
 }
 

--- a/web/lib/rpi-auth.js
+++ b/web/lib/rpi-auth.js
@@ -12,7 +12,6 @@ const rpiZenAccountPassword = process.env.RPI_ZEN_ACCOUNT_PWORD;
 
 const profileOauthPath = '/oauth2/auth';
 const profileTokenPath = '/oauth2/token';
-const profileSignupPath = '/signup';
 const profileEditPath = '/profile/edit';
 const logoutPath = '/logout';
 const loginPath = '/login';

--- a/web/lib/rpi-auth.js
+++ b/web/lib/rpi-auth.js
@@ -42,13 +42,6 @@ function getLogoutRedirectUri() {
   return `${profileServer}${logoutPath}?${params}`;
 }
 
-function getRegisterRedirectUri() {
-  const params = new URLSearchParams();
-  params.set('brand', brand);
-  params.set('returnTo', `${homeServer}${loginPath}`);
-  return `${profileServer}${profileSignupPath}?${params}`;
-}
-
 function getEditRedirectUri() {
   const params = new URLSearchParams();
   params.set('brand', brand);
@@ -125,7 +118,6 @@ module.exports = {
   decodeIdToken,
   getRedirectUri,
   getIdToken,
-  getRegisterRedirectUri,
   getLogoutRedirectUri,
   rpiZenAccountPassword,
   getEditRedirectUri,


### PR DESCRIPTION
The Join Dojo button on the club page goes in a loop of logging in to raspberry pi (and NOT CoderDojo) that isn't obvious to users, making it hard to join a club.

Add [force_signup](https://github.com/RaspberryPiFoundation/documentation/blob/bfe67fb25fbaa86e741803e44d1ba87868897691/accounts/profile-app/force-signup.md) param to handleRPIRegistration() to fix the bug.