### PR TITLE
Use the `sub` field instead of `uuid` field when logging in

### DIFF
--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -67,7 +67,7 @@ function getZenRegisterPayload(decodedIdToken, isAttendee) {
   return {
     isTrusted: true,
     user: {
-      id: decodedIdToken.user,
+      id: decodedIdToken.sub,
       name: decodedIdToken.nickname,
       firstName: decodedIdToken.name,
       lastName: '',
@@ -75,7 +75,7 @@ function getZenRegisterPayload(decodedIdToken, isAttendee) {
       password: rpiZenAccountPassword,
       termsConditionsAccepted: true,
       initUserType: { name: isAttendee ? 'attendee-o13' : 'parent-guardian' },
-      raspberryId: decodedIdToken.user,
+      raspberryId: decodedIdToken.sub,
       nick: decodedIdToken.email,
     },
     profile: {
@@ -207,7 +207,7 @@ function handleCb(request, reply) {
       {
         role: 'cd-users',
         cmd: 'get_user_by_raspberry_id',
-        raspberryId: rpiProfile.user,
+        raspberryId: rpiProfile.sub,
       },
       callback
     );


### PR DESCRIPTION
Profile returns both `uuid` for hydra v0, but with v1 [`uuid` has become `user`](https://github.com/RaspberryPiFoundation/profile/blob/main/app/services/account-authorization/scopes.js#L31).  However both v0 and v1 return `sub` which is the standard field name, so this PR changes the use of `uuid` to `sub`.

v0 decoded token looks like:
```
{ aud: 'coderdojo-dev',
  auth_time: 1681401082,
  country: 'United Kingdom',
  country_code: 'GB',
  email: 'jane.doe@example.com',
  email_verified: true,
  exp: 1681404682,
  iat: 1681401082,
  iss: 'http://localhost:9000',
  name: 'Jane Doe',
  nickname: 'Jane',
  nonce: '17902a96-5988-4658-9a25-45341a3fc75f',
  picture: 'http://localhost:3002/profile/a06c6527-0b7b-41ea-b61b-e91d25e4259c/avatar',
  postcode: null,
  profile: 'http://localhost:3002/profile',
  rat: 1681401082,
  sub: 'a06c6527-0b7b-41ea-b61b-e91d25e4259c',
  username: '',
  uuid: 'a06c6527-0b7b-41ea-b61b-e91d25e4259c' }
```

v1 decoded token looks like:

```
{ at_hash: 'OU9H5-XIFI0gBZMolTF9-g',
  aud: [ 'coderdojo-dev' ],
  auth_time: 1681383429,
  country: 'United Kingdom',
  country_code: 'GB',
  email: 'jane.doe@example.com',
  email_verified: true,
  exp: 1681405123,
  iat: 1681401523,
  iss: 'http://localhost:9001/',
  jti: '4e8822b6-e218-4f45-85d6-de9d612f449d',
  name: 'Jane Doe',
  nickname: 'Jane',
  nonce: '',
  picture: 'http://localhost:3002/profile/a06c6527-0b7b-41ea-b61b-e91d25e4259c/avatar',
  postcode: null,
  profile: 'http://localhost:3002/profile',
  rat: 1681401522,
  sid: '5d56a033-91cb-4902-90ee-0845467398a2',
  sub: 'a06c6527-0b7b-41ea-b61b-e91d25e4259c',
  user: 'a06c6527-0b7b-41ea-b61b-e91d25e4259c',
  username: '' }
  ```
