### PR TITLE
Add join as parent API endpoint

### DIFF
--- a/web/api/mastermind/dojo.js
+++ b/web/api/mastermind/dojo.js
@@ -188,12 +188,12 @@ module.exports = [
   },
   {
     method: 'POST',
-    path: `${basePath3}/dojos/{id}/join`,
-    handler: membershipHandlers.join(),
+    path: `${basePath3}/dojos/{id}/join-as-parent-guardian`,
+    handler: membershipHandlers.joinAsParentGuardian(),
     config: {
       auth: auth.apiUser,
-      description: 'Join a Dojo as a parent',
-      notes: 'Saves in the user profile and send an email to the Dojo owner',
+      description: 'Join a Dojo as a parent-guardian',
+      notes: 'Updates the users dojos role to include parent-guardian',
       tags: ['api', 'dojos', 'membership'],
       plugins: {
         cpPermissions: {

--- a/web/api/mastermind/dojo.js
+++ b/web/api/mastermind/dojo.js
@@ -188,6 +188,35 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: `${basePath3}/dojos/{id}/join`,
+    handler: membershipHandlers.join(),
+    config: {
+      auth: auth.apiUser,
+      description: 'Join a Dojo as a parent',
+      notes: 'Saves in the user profile and send an email to the Dojo owner',
+      tags: ['api', 'dojos', 'membership'],
+      plugins: {
+        cpPermissions: {
+          profiles: [{ role: 'basic-user' }],
+        },
+        'hapi-swagger': {
+          responseMessages: [
+            { code: 400, message: 'Bad Request' },
+            { code: 200, message: 'OK' },
+          ],
+        },
+      },
+      validate: {
+        params: {
+          id: Joi.string()
+            .guid()
+            .required(),
+        },
+      },
+    },
+  },
+  {
+    method: 'POST',
     path: `${basePath3}/dojos/{id}/membership-requests`,
     handler: membershipHandlers.request(),
     config: {

--- a/web/lib/handlers/membership.js
+++ b/web/lib/handlers/membership.js
@@ -90,10 +90,22 @@ const refuse = (
       reply().code(200);
     },
   ]);
+const join = (
+  params // eslint-disable-line no-unused-vars
+) =>
+  mastermind([
+    async (req, reply, next) => {
+      const dojoId = req.params.id;
+      const userId = req.user.user.id;
+      req.app.membership = await Membership.create(userId, dojoId, 'parent-guardian');
+      reply(req.app.membership).code(200);
+    }
+  ]);
 
 module.exports = {
   request,
+  loadPending,
   accept,
   refuse,
-  loadPending,
+  join
 };

--- a/web/lib/handlers/membership.js
+++ b/web/lib/handlers/membership.js
@@ -94,7 +94,7 @@ const joinAsParentGuardian = (
   params // eslint-disable-line no-unused-vars
 ) =>
   mastermind([
-    async (req, reply, next) => {
+    async (req, reply) => {
       const dojoId = req.params.id;
       const userId = req.user.user.id;
       req.app.membership = await Membership.create(userId, dojoId, 'parent-guardian');

--- a/web/lib/handlers/membership.js
+++ b/web/lib/handlers/membership.js
@@ -90,7 +90,7 @@ const refuse = (
       reply().code(200);
     },
   ]);
-const join = (
+const joinAsParentGuardian = (
   params // eslint-disable-line no-unused-vars
 ) =>
   mastermind([
@@ -107,5 +107,5 @@ module.exports = {
   loadPending,
   accept,
   refuse,
-  join
+  joinAsParentGuardian
 };

--- a/web/lib/handlers/membership.js
+++ b/web/lib/handlers/membership.js
@@ -97,15 +97,19 @@ const joinAsParentGuardian = (
     async (req, reply) => {
       const dojoId = req.params.id;
       const userId = req.user.user.id;
-      req.app.membership = await Membership.create(userId, dojoId, 'parent-guardian');
+      req.app.membership = await Membership.create(
+        userId,
+        dojoId,
+        'parent-guardian'
+      );
       reply(req.app.membership).code(200);
-    }
+    },
   ]);
 
 module.exports = {
   request,
-  loadPending,
   accept,
   refuse,
-  joinAsParentGuardian
+  loadPending,
+  joinAsParentGuardian,
 };


### PR DESCRIPTION
This allows a request to be made to update a users roles on a Dojo to include parent-guardian, returning an error if that role already exists:
```
curl --request POST 'http://localhost:8000/api/3.0/dojos/DOJO-ID/join-as-parent-guardian' \
--header 'Authorization: Bearer TOKEN'
{"id":"7a3d718b-18af-4f47-b4f8-c03b7285a5eb","userId":"USER-ID","dojoId":"DOJO-ID","userTypes":["parent-guardian"],"userPermissions":[],"mysqlUserId":null,"mysqlDojoId":null,"owner":null,"backgroundChecked":false,"deleted":0,"deletedBy":null,"deletedAt":null}
```

And then, if the same POST is made again:
```
curl --request POST 'http://localhost:8000/api/3.0/dojos/DOJO-ID/join-as-parent-guardian' \
--header 'Authorization: Bearer TOKEN'
{"statusCode":400,"error":"Bad Request","message":"400 - \"Membership already has this role\""}
```