### PR TITLE
Update build process to use Debian Buster to fix SSL certificate issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     working_directory: ~/cp-zen-platform
     docker:
-      - image: node:carbon
+      - image: node:8-buster
         environment:
           NODE_ENV: testing
           EVENTS_SERVICE: events2
@@ -15,6 +15,11 @@ jobs:
       - run:
           name: Use secure GitHub URLs
           command: git config --global url."git@github.com:".insteadOf git://github.com/
+      - run:
+          name: Configure SSL certs
+          command: |
+            sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf
+            update-ca-certificates
       - run:
           name: Install Dependencies
           command: yarn
@@ -58,7 +63,7 @@ jobs:
   update-frontend:
     working_directory: ~/cp-zen-platform
     docker:
-      - image: node:carbon
+      - image: node:8-buster
     steps:
       - add-ssh-keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
         environment:
           NODE_ENV: testing
           EVENTS_SERVICE: events2
+          NODE_OPTIONS: --use-openssl-ca
     steps:
       - checkout
       - restore_cache:
@@ -16,7 +17,7 @@ jobs:
           name: Use secure GitHub URLs
           command: git config --global url."git@github.com:".insteadOf git://github.com/
       - run:
-          name: Configure SSL certs
+          name: Fix up SSL certificates
           command: |
             sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf
             update-ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM node:8-alpine
+FROM node:8-buster-slim AS base
 MAINTAINER butlerx <butlerx@notthe.cloud>
-RUN apk add --update git make gcc g++ python openssh && \
-    mkdir -p /usr/src/app
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_OPTIONS=--use-openssl-ca
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends build-essential git python3
+RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
+RUN git config --global url."https://github.com/".insteadOf git://github.com/ && \
+    sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf && \
+    update-ca-certificates
 COPY . /usr/src/app/
-RUN git config --global url."https://github.com/".insteadOf git://github.com/
 RUN yarn && \
     node_modules/.bin/bower install --allow-root && \
     yarn build && \
-    apk del make gcc g++ python && \
-    rm -rf /tmp/* /root/.npm /root/.node-gyp
+    apt-get clean && apt-get remove -y --purge build-essential git python3 && apt-get -y autoclean && \
+    rm -rf /tmp/* /root/.npm /root/.node-gyp /var/cache/apt/lists/*
 EXPOSE 8000
 CMD ["yarn", "start"]


### PR DESCRIPTION
When installing packages with bower, recent SSL certificate changes have caused errors like

```
bower CERT_HAS_EXPIRED      Request to https://registry.bower.io/packages/angular-google-maps failed: certificate has expired
error Command failed with exit code 1.
```

which cause both the circleci test process and docker build process to fail.

The solution is to set `NODE_OPTIONS=--use-openssl-ca` in the environment, however this doesn't appear to work for the Alpine builds of node.  It does however work for Debian Buster version.

This PR updates the Dockerfile to start from `node:8-buster-slim` and build from there.  There resulting docker image is just over 1.1GB, but that's the best I could do.  I tried using layers but that didn't make the resulting size smaller.

I have run the built container locally and it all works. 🤞 it works in prod too.. (we can roll back if not)
