### PR TITLE
Add `v1_signup` login option

### DIFF
--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -25,7 +25,7 @@ function getErrorRedirectUrl(message = oauthErrorMessage) {
   return `/?${errorUrlQueryParams}`;
 }
 
-function handleRPILogin(request, reply, redirectQueryParams = {}) {
+function handleRPILogin(request, reply, redirectQueryParams = { login_options: 'v1_signup' }) {
   const returnTo = request.query['returnTo'];
   const state = crypto.randomBytes(20).toString('hex');
 
@@ -57,7 +57,7 @@ function handleRPIRegister(request, reply) {
     return reply.redirect('/');
   }
 
-  handleRPILogin(request, reply, { login_options: 'force_signup' })
+  handleRPILogin(request, reply, { login_options: 'force_signup,v1_signup' })
 }
 
 function handleRPIEdit(request, reply) {


### PR DESCRIPTION
This means that if a user decides to sign up during the login flow, they get redirected back to Zen correctly.

In [rpi-auth](https://github.com/RaspberryPiFoundation/rpi-auth/blob/33fec8292d805d00d0f50cd1b8731fd03034ad91/config/routes.rb#L8) we've added them in as options to the `login_path` route.