### PR TITLE
Refactor login/logout to share session clearing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ It also contains our legacy front-end. In case of large PR regarding our front-e
 If you want to get set up to make a contribution, please see the [cp-local-development repository](https://github.com/CoderDojo/cp-local-development).
 
 General documentation is in the [community-platform repository](https://github.com/CoderDojo/community-platform).
+
+## Debugging
+
+You can see HAPI interactions by setting `HAPI_DEBUG` to `true` in `web/config/development.env`.  This then outputs data to `/tmp/hapi-zen-platform.log` inside the zen container.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,6 +184,9 @@ gulp.task('dev', ['watch-less'], () => {
       relativePath('./web/public/components/*'),
       relativePath('./web/public/dist/*'),
     ],
+    execMap: {
+      js: "node --max-http-header-size=81920"
+    },
     script: 'index.js',
     ext: 'js dust json',
     tasks: ['build'],

--- a/web/config/development.env
+++ b/web/config/development.env
@@ -2,7 +2,6 @@ EVENTS_SERVICE=events2
 EMAIL_SERVICE=email
 USERS_SERVICE=users
 CLUBS_SERVICE=clubs
-# Send HAPI debug logs to /tmp/hapi-zen-platform.log
 HAPI_DEBUG=false
 HOSTED_URL=http://localhost:8000
 RPI_AUTH_URL=http://localhost:9001/

--- a/web/config/development.env
+++ b/web/config/development.env
@@ -2,6 +2,8 @@ EVENTS_SERVICE=events2
 EMAIL_SERVICE=email
 USERS_SERVICE=users
 CLUBS_SERVICE=clubs
+# Send HAPI debug logs to /tmp/hapi-zen-platform.log
+HAPI_DEBUG=false
 HOSTED_URL=http://localhost:8000
 RPI_AUTH_URL=http://localhost:9001/
 RPI_PROFILE_URL=http://localhost:3002

--- a/web/controllers/rpi/index.js
+++ b/web/controllers/rpi/index.js
@@ -26,6 +26,8 @@ function getErrorRedirectUrl(message = oauthErrorMessage) {
 }
 
 function handleRPILogin(request, reply, redirectQueryParams = { login_options: 'v1_signup' }) {
+  clearSession(request, reply);
+
   const returnTo = request.query['returnTo'];
   const state = crypto.randomBytes(20).toString('hex');
 
@@ -35,6 +37,8 @@ function handleRPILogin(request, reply, redirectQueryParams = { login_options: '
 }
 
 function handleRPILogout(request, reply) {
+  clearSession(request, reply);
+
   const session = request.state['seneca-login'];
   if (!session || (session && !session.token)) {
     return reply.redirect('/');
@@ -43,9 +47,7 @@ function handleRPILogout(request, reply) {
   const msg = { role: 'user', cmd: 'logout', token: session.token };
   return request.seneca.act(msg, err => {
     if (err) return reply(Boom.badImplementation(err));
-    request.cookieAuth.clear();
-    clearRpiStateCookie(reply);
-    delete request.user;
+
     const redirectUri = getLogoutRedirectUri();
     return reply.redirect(redirectUri);
   });
@@ -63,6 +65,12 @@ function handleRPIRegister(request, reply) {
 function handleRPIEdit(request, reply) {
   const redirectUri = getEditRedirectUri();
   reply.redirect(redirectUri);
+}
+
+function clearSession(request, reply) {
+  request.cookieAuth.clear();
+  clearRpiStateCookie(reply);
+  delete request.user;
 }
 
 function getZenRegisterPayload(decodedIdToken, isAttendee) {


### PR DESCRIPTION
I noticed that when logging in with another user on top of an existing session that the old session was still present on the "account select" screen.  This change makes sure the session is cleared before going through the login flow, the same way as it is cleared in the logout flow.

Also I've added an option to the gulpfile to allow large HTTP headers to be parsed, as I was seeing HPE_HEADER_OVERFLOW errors in the HAPI debug logs.  I don't think this will happen in prod as not as many cookies are sent, as more than one domain is used for profile, zen, cd frontend etc.